### PR TITLE
Rails 3.1.0.rc6 compatibility with field option

### DIFF
--- a/lib/by_star/shared.rb
+++ b/lib/by_star/shared.rb
@@ -1,6 +1,6 @@
 module Shared
   def conditions_for_range(start_time, end_time, field=nil)
-    field = table_name << '.' << field.to_s if field
+    field = "#{table_name}.#{field}" if field
     field ||= by_star_field
     ["#{field} >= ? AND #{field} <= ?", start_time.utc, end_time.utc]
   end


### PR DESCRIPTION
When testing in Rails 3.1.0.rc6 (and probably earlier versions) the table_name gets messed up:

For example:

```
> Foo.table_name 
=> "foos"
> Foo.by_day(Time.now)
=> []
> Foo.by_day(Time.now, :field => 'activity_at')
ActiveRecord::StatementInvalid: Mysql::Error: Table 'foos.activity_at' doesn't exist: SHOW FIELDS FROM `question_composition_points`.`created_at`
> Foo.by_day(Time.now, :field => 'activity_at')
ActiveRecord::StatementInvalid: Mysql::Error: Table 'foos.activity_at.activity_at' doesn't exist: SHOW FIELDS FROM `foos`.`activity_at`.`activity_at`
```

This stems for the code in `conditions_for_range`. Using the `<<` operator on `table_name` actually edits the table name rather than just concatenating a string. I've made a pull request which changes this to use string interpolation instead. This should be Rails 2 backwards compatible as well.

Thanks

Theo
