### PR TITLE
Segregate tests by db/orm; add rake test tasks

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -334,6 +334,16 @@ Or if you're doing it all the time on your model, then it's best to use `by_star
 
 Mongoid is only tested/supported on version 3.0+
 
+## Testing
+
+Specify a database by supplying a `DB` environmental variable:
+
+`bundle exec rake spec DB=sqlite`
+
+You can also take an ORM-specific test task for a ride:
+
+`bundle exec rake spec:active_record`
+
 ## Collaborators
 
 Thanks to Thomas Sinclair for the original bump for implementing it. I would like to thank #rubyonrails for their support and the following people:

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,16 @@
 require 'bundler'
+require 'rspec/core/rake_task'
+
 Bundler::GemHelper.install_tasks
+RSpec::Core::RakeTask.new(:spec)
+
+def orm_test(orm)
+  RSpec::Core::RakeTask.new(orm) do |task|
+    task.pattern = "./spec/by_star/#{orm}/{,/*/**}/*_spec.rb"
+  end
+end
+
+namespace :spec do
+  orm_test 'active_record'
+  orm_test 'mongoid'
+end

--- a/spec/by_star/active_record/active_record_spec.rb
+++ b/spec/by_star/active_record/active_record_spec.rb
@@ -47,4 +47,4 @@ describe ActiveRecord do
       Post.between_times(Date.today - 2, Date.today).should == Post.between(Date.today - 2, Date.today)
     end
   end
-end
+end if testing_active_record?

--- a/spec/by_star/mongoid/mongoid_spec.rb
+++ b/spec/by_star/mongoid/mongoid_spec.rb
@@ -41,4 +41,4 @@ describe 'mongoid', :if => Gem::Version.create(RUBY_VERSION.dup) >= Gem::Version
       Post.between_times(Date.today - 2, Date.today).should == Post.between(Date.today - 2, Date.today)
     end
   end
-end
+end if testing_mongoid?

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,8 +28,20 @@ Timecop.travel(Time.zone.local(Time.zone.now.year, 1, 1, 0, 0, 1, 0))
 #   super caller.first if caller.first.index("shoulda.rb") == -1
 #   super str
 # end
-# 
+#
 # def p obj
 #   puts caller.first
 #   super obj
 # end
+
+#
+# Tests should be according to the database specified at runtime
+#
+
+def testing_mongoid?
+  ENV['DB'] == 'mongodb' || ENV['DB'].nil?
+end
+
+def testing_active_record?
+  ENV['DB'] != 'mongodb'
+end


### PR DESCRIPTION
Just added some rake tasks to ease testing and added unsophisticated means to target a DB/ORM. For example:

``` bash
bundle exec rake spec:active_record
bundle exec rake spec DB=mongodb
```

 :smile:
