### PR TITLE
Deprecate `between` method for ActiveRecord

### DIFF
--- a/UPGRADING
+++ b/UPGRADING
@@ -1,9 +1,11 @@
 Upgrading to ByStar 2.2.0
 -------------------------
 
-* For Mongoid only, ByStar's `.between` method has been removed and replaced with `.between_times`
-(previously `.between_times` was an alias to `.between`). Mongoid already provides a native `.between`
-finder method that we do not want to mask. ActiveRecord users may continue to use either method.
+* ActiveRecord: the `between` method has been deprecated as of version 2.2.0, and will be removed in version 3.3.0.
+Please use `between_times` instead.
+
+* Mongoid: the `between` method has been removed as of version 2.2.0, as it conflicts with the native Mongoid `between`
+method. Please use `between_times` instead.
 
 * Chronic gem (used for time string parsing) has been removed as a hard dependency for ByStar,
 however it is still supported. If you would like to use Chronic with ByStar, please explicitly

--- a/lib/by_star/orm/active_record/by_star.rb
+++ b/lib/by_star/orm/active_record/by_star.rb
@@ -18,7 +18,10 @@ module ByStar
         scope
       end
 
-      alias_method :between, :between_times
+      def between(*args)
+        ActiveSupport::Deprecation.warn 'ByStar `between` method will be removed in v3.0.0. Please use `between_times`'
+        between_times(*args)
+      end
 
       protected
 


### PR DESCRIPTION
I propose to deprecate `between` method for ActiveRecord, as it is set in the global ActiveRecord::Model scope and is likely to conflict with other gems. It is replaced with `between_times`

I've already removed `between` for Mongoid in a previous commit, since it conflicts with a native Mongoid method.

@radar please confirm.
