### PR TITLE
Bug Fix: :field, :start_field, and :end_field options were being ignored on finder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## Unreleased
+
+* Feature: Add past_week, past_month, and past_fornight finders
+* Bug Fix: :field, :start_field, and :end_field options were being ignored on finder
+
 ## v2.2.0
 
 * Begin tracking CHANGELOG

--- a/lib/by_star/orm/active_record/by_star.rb
+++ b/lib/by_star/orm/active_record/by_star.rb
@@ -9,10 +9,13 @@ module ByStar
       #
       # Currently only supports Time objects.
       def between_times_query(start, finish, options={})
-        scope = if options[:strict] || by_star_start_field == by_star_end_field
-          where("#{by_star_start_field} >= ? AND #{by_star_end_field} <= ?", start, finish)
+        start_field = by_star_start_field(options)
+        end_field = by_star_end_field(options)
+
+        scope = if options[:strict] || start_field == end_field
+          where("#{start_field} >= ? AND #{end_field} <= ?", start, finish)
         else
-          where("#{by_star_end_field} > ? AND #{by_star_start_field} < ?", start, finish)
+          where("#{end_field} > ? AND #{start_field} < ?", start, finish)
         end
         scope = scope.order(options[:order]) if options[:order]
         scope

--- a/lib/by_star/orm/mongoid/by_star.rb
+++ b/lib/by_star/orm/mongoid/by_star.rb
@@ -10,10 +10,13 @@ module Mongoid
       include ::ByStar::Base
 
       def between_times_query(start, finish, options={})
-        scope = if options[:strict] || by_star_start_field == by_star_end_field
-          gte(by_star_start_field => start).lte(by_star_end_field => finish)
+        start_field = by_star_start_field(options)
+        end_field = by_star_end_field(options)
+
+        scope = if options[:strict] || start_field == end_field
+          gte(start_field => start).lte(end_field => finish)
         else
-          gt(by_star_end_field => start).lt(by_star_start_field => finish)
+          gt(end_field => start).lt(start_field => finish)
         end
         scope = scope.order_by(field => options[:order]) if options[:order]
         scope

--- a/spec/fixtures/active_record/schema.rb
+++ b/spec/fixtures/active_record/schema.rb
@@ -6,6 +6,7 @@ ActiveRecord::Schema.define do
   end
 
   create_table :events, :force => true do |t|
+    t.timestamps
     t.datetime :start_time, :end_time
   end
 end

--- a/spec/fixtures/mongoid/models.rb
+++ b/spec/fixtures/mongoid/models.rb
@@ -6,6 +6,7 @@ end
 
 class Event
   include Mongoid::Document
+  include Mongoid::Timestamps
   include Mongoid::ByStar
 
   field :st, as: :start_time, type: Time

--- a/spec/fixtures/shared/seeds.rb
+++ b/spec/fixtures/shared/seeds.rb
@@ -21,5 +21,5 @@
    2014-04-01
    2014-04-15).map{|d| Time.zone.parse(d) + 17.hours }.each do |d|
   Post.create!(:created_at => d)
-  Event.create!(:start_time => d - 5.days, :end_time => d + 5.days)
+  Event.create!(:created_at => d, :start_time => d - 5.days, :end_time => d + 5.days)
 end

--- a/spec/integration/shared/by_calendar_month.rb
+++ b/spec/integration/shared/by_calendar_month.rb
@@ -44,7 +44,7 @@ shared_examples_for 'by calendar month' do
     end
 
     it 'should be able to use an alternative field' do
-      Event.by_calendar_month(:field => 'end_time').count.should eq 10
+      Event.by_calendar_month(:field => 'end_time').count.should eq 9
     end
 
     context ':start_day option' do

--- a/spec/integration/shared/by_day.rb
+++ b/spec/integration/shared/by_day.rb
@@ -20,7 +20,7 @@ shared_examples_for 'by day' do
     end
 
     it 'should be able to use an alternative field' do
-      Event.by_day(:field => 'end_time').count.should eq 5
+      Event.by_day(:field => 'end_time').count.should eq 0
     end
 
     it 'should support :offset option' do
@@ -44,6 +44,14 @@ shared_examples_for 'by day' do
       subject { Event.today(strict: true) }
       its(:count){ should eq 0 }
     end
+
+    it 'should be able to use an alternative field' do
+      Event.today(:field => 'created_at').count.should eq 2
+    end
+
+    it 'should support :offset option' do
+      Post.today(:offset => -24.hours).count.should eq 1
+    end
   end
 
   describe '#yesterday' do # 2013-12-31
@@ -62,6 +70,14 @@ shared_examples_for 'by day' do
       subject { Event.yesterday(strict: true) }
       its(:count){ should eq 0 }
     end
+
+    it 'should be able to use an alternative field' do
+      Event.yesterday(:field => 'created_at').count.should eq 1
+    end
+
+    it 'should support :offset option' do
+      Post.yesterday(:offset => 24.hours).count.should eq 2
+    end
   end
 
   describe '#tomorrow' do # 2014-01-02
@@ -79,6 +95,14 @@ shared_examples_for 'by day' do
     context 'timespan strict' do
       subject { Event.tomorrow(strict: true) }
       its(:count){ should eq 0 }
+    end
+
+    it 'should be able to use an alternative field' do
+      Event.tomorrow(:field => 'created_at').count.should eq 0
+    end
+
+    it 'should support :offset option' do
+      Post.tomorrow(:offset => -24.hours).count.should eq 2
     end
   end
 end

--- a/spec/integration/shared/by_fortnight.rb
+++ b/spec/integration/shared/by_fortnight.rb
@@ -42,7 +42,7 @@ shared_examples_for 'by fortnight' do
     end
 
     it 'should be able to use an alternative field' do
-      Event.by_fortnight(:field => 'end_time').count.should eq 7
+      Event.by_fortnight(:field => 'end_time').count.should eq 5
     end
   end
 end

--- a/spec/integration/shared/by_month.rb
+++ b/spec/integration/shared/by_month.rb
@@ -44,7 +44,7 @@ shared_examples_for 'by month' do
     end
 
     it 'should be able to use an alternative field' do
-      Event.by_month(:field => 'end_time').count.should eq 9
+      Event.by_month(:field => 'end_time').count.should eq 8
     end
   end
 end

--- a/spec/integration/shared/by_quarter.rb
+++ b/spec/integration/shared/by_quarter.rb
@@ -43,7 +43,7 @@ shared_examples_for 'by quarter' do
     end
 
     it 'should be able to use an alternative field' do
-      Event.by_quarter(1, :field => 'end_time').count.should eq 13
+      Event.by_quarter(1, :field => 'end_time').count.should eq 12
     end
   end
 end

--- a/spec/integration/shared/by_week.rb
+++ b/spec/integration/shared/by_week.rb
@@ -43,7 +43,7 @@ shared_examples_for 'by week' do
     end
 
     it 'should be able to use an alternative field' do
-      Event.by_week(:field => 'end_time').count.should eq 7
+      Event.by_week(:field => 'end_time').count.should eq 3
     end
 
     context ':start_day option' do

--- a/spec/integration/shared/by_weekend.rb
+++ b/spec/integration/shared/by_weekend.rb
@@ -43,7 +43,7 @@ shared_examples_for 'by weekend' do
     end
 
     it 'should be able to use an alternative field' do
-      Event.by_weekend(:field => 'end_time').count.should eq 5
+      Event.by_weekend(:field => 'end_time').count.should eq 1
     end
   end
 end


### PR DESCRIPTION
Found a bug related to inline options for finders.
