### PR TITLE
Change deprecated Date#to_time_in_current_zone to use Date#in_time_zone instead

### DIFF
--- a/lib/by_star/normalization.rb
+++ b/lib/by_star/normalization.rb
@@ -10,7 +10,13 @@ module ByStar
         case value
           when String then time_string(value)
           when DateTime then value.to_time
-          when Date then value.in_time_zone
+          when Date
+            begin
+              value.in_time_zone
+            rescue NoMethodError
+              # fallback to deprecated method
+              value.to_time_in_current_zone
+            end
           else value
         end
       end


### PR DESCRIPTION
I was using this gem in a Rails 4 app and came across a deprecated method being used. 

This is the warning I am currently getting: 
`DEPRECATION WARNING: Date#to_time_in_current_zone is deprecated. Use Date#in_time_zone instead.`

Here is a note in the Rails API mentioning the deprecation: 
http://api.rubyonrails.org/classes/Date.html#method-i-to_time_in_current_zone

I changed the `Normalization#time` method to use `#in_time_zone` exclusively but it broke some of your tests. I then set up a rescue for `NoMethodError` to use `#to_time_in_current_zone` as a fallback for backwards compatibility.

Thanks for your work on this project, this gem is awesome!
