### PR TITLE
Fix code braces for by_month in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ or
 
 ```ruby
    Post.by_month("January", :year => 2007)
+```
 
 This will perform a find using the column you've specified.
 


### PR DESCRIPTION
Fixes markdown code braces for the `by_month` section of the README.
