### PR TITLE
Update to Rspec 3.1

### DIFF
--- a/by_star.gemspec
+++ b/by_star.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "mongoid"
   s.add_development_dependency "pg"
   s.add_development_dependency "mysql2"
-  s.add_development_dependency "rspec-rails", "~> 2.14"
+  s.add_development_dependency "rspec-rails", "~> 3.1.0"
   s.add_development_dependency "timecop", "~> 0.3"
   s.add_development_dependency "pry"
 

--- a/spec/integration/active_record/active_record_spec.rb
+++ b/spec/integration/active_record/active_record_spec.rb
@@ -35,19 +35,19 @@ describe ActiveRecord do
 
   it 'should be able to order the result set' do
     scope = Post.by_year(Time.zone.now.year, :order => 'created_at DESC')
-    scope.order_values.should == ['created_at DESC']
+    expect(scope.order_values).to eq ['created_at DESC']
   end
 
   describe '#between_times' do
     subject { Post.between_times(Time.parse('2014-01-01'), Time.parse('2014-01-06')) }
-    it { should be_a(ActiveRecord::Relation) }
-    its(:count) { should eq 3 }
+    it { expect be_a(ActiveRecord::Relation) }
+    it { expect(subject.count).to eql(3) }
   end
 
   describe '#between' do
     subject { Post.between(Time.parse('2014-01-01'), Time.parse('2014-01-06')) }
     it 'should be an alias of #between_times' do
-      subject.count.should eq 3
+      expect(subject.count).to eql(3)
     end
   end
 end if testing_active_record?

--- a/spec/integration/mongoid/mongoid_spec.rb
+++ b/spec/integration/mongoid/mongoid_spec.rb
@@ -35,12 +35,13 @@ describe 'Mongoid' do
   describe '#between_times' do
     subject { Post.between_times(Time.parse('2014-01-01'), Time.parse('2014-01-06')) }
     it { should be_a(Mongoid::Criteria) }
-    its(:count) { should eq 3 }
+    it { expect(subject.count).to eql(3) }
   end
 
   describe '#between' do
     it 'should not override Mongoid between method' do
-      Post.between(created_at: Time.parse('2014-01-01')..Time.parse('2014-01-06')).count.should eq 3
+      posts = Post.between(created_at: Time.parse('2014-01-01')..Time.parse('2014-01-06'))
+      expect(posts.count).to eql(3)
     end
   end
 end if testing_mongoid?

--- a/spec/integration/shared/by_calendar_month.rb
+++ b/spec/integration/shared/by_calendar_month.rb
@@ -6,50 +6,50 @@ shared_examples_for 'by calendar month' do
 
     context 'point-in-time' do
       subject { Post.by_calendar_month('Feb') }
-      its(:count){ should eq 3 }
+      it { expect(subject.count).to eql(3) }
     end
 
     context 'timespan' do
       subject { Event.by_calendar_month(1) }
-      its(:count){ should eq 10 }
+      it { expect(subject.count).to eql(10) }
     end
 
     context 'timespan strict' do
       subject { Event.by_calendar_month(Date.parse('2014-02-01'), strict: true) }
-      its(:count){ should eq 2 }
+      it { expect(subject.count).to eql(2) }
     end
 
     context 'with :year option' do
 
       context 'point-in-time' do
         subject { Post.by_calendar_month(12, year: 2013) }
-        its(:count){ should eq 12 }
+        it { expect(subject.count).to eql(12) }
       end
 
       context 'timespan' do
         subject { Event.by_calendar_month('December', year: 2013) }
-        its(:count){ should eq 13 }
+        it { expect(subject.count).to eql(13) }
       end
 
       context 'timespan strict' do
         subject { Event.by_calendar_month('Dec', year: 2013, strict: true) }
-        its(:count){ should eq 9 }
+        it { expect(subject.count).to eql(9) }
       end
     end
 
     it 'should raise an error when given an invalid argument' do
-      ->{ Post.by_calendar_month(0) }.should raise_error(ByStar::ParseError, 'Month must be a number between 1 and 12 or a month name')
-      ->{ Post.by_calendar_month(13) }.should raise_error(ByStar::ParseError, 'Month must be a number between 1 and 12 or a month name')
-      ->{ Post.by_calendar_month('foobar') }.should raise_error(ByStar::ParseError, 'Month must be a number between 1 and 12 or a month name')
+      expect{ Post.by_calendar_month(0) }.to raise_error(ByStar::ParseError, 'Month must be a number between 1 and 12 or a month name')
+      expect{ Post.by_calendar_month(13) }.to raise_error(ByStar::ParseError, 'Month must be a number between 1 and 12 or a month name')
+      expect{ Post.by_calendar_month('foobar') }.to raise_error(ByStar::ParseError, 'Month must be a number between 1 and 12 or a month name')
     end
 
     it 'should be able to use an alternative field' do
-      Event.by_calendar_month(:field => 'end_time').count.should eq 9
+      expect(Event.by_calendar_month(:field => 'end_time').count).to eql(9)
     end
 
     context ':start_day option' do
       subject { Post.by_calendar_month(1, :start_day => :wednesday) }
-      its(:count){ should eq 7 }
+      it{ expect(subject.count).to eql(7) }
     end
   end
 end

--- a/spec/integration/shared/by_day.rb
+++ b/spec/integration/shared/by_day.rb
@@ -5,104 +5,92 @@ shared_examples_for 'by day' do
   describe '#by_day' do
 
     context 'point-in-time' do
-      subject { Post.by_day('2014-01-01') }
-      its(:count){ should eq 2 }
+      it { expect(Post.by_day('2014-01-01').count).to eql(2) }
     end
 
     context 'timespan' do
-      subject { Event.by_day(Time.parse '2014-01-01') }
-      its(:count){ should eq 5 }
+      it { expect(Event.by_day(Time.parse '2014-01-01').count).to eql(5) }
     end
 
     context 'timespan strict' do
-      subject { Event.by_day(Date.parse('2014-01-01'), strict: true) }
-      its(:count){ should eq 0 }
+      it { expect(Event.by_day(Date.parse('2014-01-01'), strict: true).count).to eql(0) }
     end
 
     it 'should be able to use an alternative field' do
-      Event.by_day(:field => 'end_time').count.should eq 0
+      expect(Event.by_day(:field => 'end_time').count).to eql(0)
     end
 
     it 'should support :offset option' do
-      Post.by_day('2014-01-01', :offset => -16.hours).count.should eq 1
+      expect(Post.by_day('2014-01-01', :offset => -16.hours).count).to eq(1)
     end
   end
 
   describe '#today' do # 2014-01-01
 
     context 'point-in-time' do
-      subject { Post.today }
-      its(:count){ should eq 2 }
+      it { expect(Post.today.count).to eql(2) }
     end
 
     context 'timespan' do
-      subject { Event.today }
-      its(:count){ should eq 5 }
+      it { expect(Event.today.count).to eql(5) }
     end
 
     context 'timespan strict' do
-      subject { Event.today(strict: true) }
-      its(:count){ should eq 0 }
+      it { expect(Event.today(strict: true).count).to eql(0) }
     end
 
     it 'should be able to use an alternative field' do
-      Event.today(:field => 'created_at').count.should eq 2
+      expect(Event.today(:field => 'created_at').count).to eql(2)
     end
 
     it 'should support :offset option' do
-      Post.today(:offset => -24.hours).count.should eq 1
+      expect(Post.today(:offset => -24.hours).count).to eql(1)
     end
   end
 
   describe '#yesterday' do # 2013-12-31
 
     context 'point-in-time' do
-      subject { Post.yesterday }
-      its(:count){ should eq 1 }
+      it { expect(Post.yesterday.count).to eql(1) }
     end
 
     context 'timespan' do
-      subject { Event.yesterday }
-      its(:count){ should eq 5 }
+      it { expect(Event.yesterday.count).to eql(5) }
     end
 
     context 'timespan strict' do
-      subject { Event.yesterday(strict: true) }
-      its(:count){ should eq 0 }
+      it { expect(Event.yesterday(strict: true).count).to eql(0) }
     end
 
     it 'should be able to use an alternative field' do
-      Event.yesterday(:field => 'created_at').count.should eq 1
+      expect(Event.yesterday(:field => 'created_at').count).to eql(1)
     end
 
     it 'should support :offset option' do
-      Post.yesterday(:offset => 24.hours).count.should eq 2
+      expect(Post.yesterday(:offset => 24.hours).count).to eql(2)
     end
   end
 
   describe '#tomorrow' do # 2014-01-02
 
     context 'point-in-time' do
-      subject { Post.tomorrow }
-      its(:count){ should eq 0 }
+      it { expect(Post.tomorrow.count).to eql(0) }
     end
 
     context 'timespan' do
-      subject { Event.tomorrow }
-      its(:count){ should eq 5 }
+      it { expect(Event.tomorrow.count).to eql(5) }
     end
 
     context 'timespan strict' do
-      subject { Event.tomorrow(strict: true) }
-      its(:count){ should eq 0 }
+      it { expect(Event.tomorrow(strict: true).count).to eql(0) }
     end
 
     it 'should be able to use an alternative field' do
-      Event.tomorrow(:field => 'created_at').count.should eq 0
+      expect(Event.tomorrow(:field => 'created_at').count).to eql(0)
     end
 
     it 'should support :offset option' do
-      Post.tomorrow(:offset => -24.hours).count.should eq 2
+      expect(Post.tomorrow(:offset => -24.hours).count).to eql(2)
     end
   end
 end

--- a/spec/integration/shared/by_direction.rb
+++ b/spec/integration/shared/by_direction.rb
@@ -6,37 +6,37 @@ shared_examples_for 'by direction' do
 
     context 'point-in-time' do
       subject { Post.before(Date.parse '2014-01-05') }
-      its(:count){ should eq 12 }
+      it { expect(subject.count).to eql(12) }
     end
 
     context 'timespan' do
       subject { Event.before(Time.parse '2014-01-05') }
-      its(:count){ should eq 13 }
+      it { expect(subject.count).to eql(13) }
     end
 
     context 'timespan strict' do
       subject { Event.before('2014-01-05', strict: true) }
-      its(:count){ should eq 13 }
+      it { expect(subject.count).to eql(13) }
     end
 
     context 'alternative field' do
       subject { Event.before('2014-01-05', field: 'created_at') }
-      its(:count){ should eq 12 }
+      it { expect(subject.count).to eql(12) }
     end
 
     context 'with default scope' do
       subject { Appointment.before('2014-01-05', field: 'created_at') }
-      its(:count){ should eq 4 }
+      it { expect(subject.count).to eql(4) }
     end
 
     context 'with scope as a query criteria' do
       subject { Post.before('2014-01-05', field: 'created_at', scope: Post.where(day_of_month: 5)) }
-      its(:count){ should eq 1 }
+      it { expect(subject.count).to eql(1) }
     end
 
     context 'with scope as a proc' do
       subject { Post.before('2014-01-05', field: 'created_at', scope: ->{ where(day_of_month: 5) }) }
-      its(:count){ should eq 1 }
+      it { expect(subject.count).to eql(1) }
     end
   end
 
@@ -44,75 +44,75 @@ shared_examples_for 'by direction' do
 
     context 'point-in-time' do
       subject { Post.after('2014-01-05') }
-      its(:count){ should eq 10 }
+      it { expect(subject.count).to eql(10) }
     end
 
     context 'timespan' do
       subject { Event.after(Date.parse '2014-01-05') }
-      its(:count){ should eq 9 }
+      it { expect(subject.count).to eql(9) }
     end
 
     context 'timespan strict' do
       subject { Event.after('2014-01-05', strict: true) }
-      its(:count){ should eq 9 }
+      it { expect(subject.count).to eql(9) }
     end
 
     context 'alternative field' do
       subject { Event.after('2014-01-05', field: 'created_at') }
-      its(:count){ should eq 10 }
+      it { expect(subject.count).to eql(10) }
     end
 
     context 'with default scope' do
       subject { Appointment.after('2014-01-05', field: 'created_at') }
-      its(:count){ should eq 3 }
+      it { expect(subject.count).to eql(3) }
     end
 
     context 'with scope as a query criteria' do
       subject { Post.after('2014-01-05', field: 'created_at', scope: Post.where(day_of_month: 5)) }
-      its(:count){ should eq 1 }
+      it { expect(subject.count).to eql(1) }
     end
 
     context 'with scope as a proc' do
       subject { Post.after('2014-01-05', field: 'created_at', scope: ->{ where(day_of_month: 5) }) }
-      its(:count){ should eq 1 }
+      it { expect(subject.count).to eql(1) }
     end
   end
 
   describe '#oldest and #newest' do
 
     context 'point-in-time' do
-      it { Post.newest.created_at.should eq Time.zone.parse('2014-04-15 17:00:00') }
-      it { Post.oldest.created_at.should eq Time.zone.parse('2013-11-01 17:00:00') }
+      it { expect(Post.newest.created_at).to eq Time.zone.parse('2014-04-15 17:00:00') }
+      it { expect(Post.oldest.created_at).to eq Time.zone.parse('2013-11-01 17:00:00') }
     end
 
     context 'timespan' do
-      it { Event.newest.created_at.should eq Time.zone.parse('2014-04-15 17:00:00') }
-      it { Event.oldest.created_at.should eq Time.zone.parse('2013-11-01 17:00:00') }
+      it { expect(Event.newest.created_at).to eq Time.zone.parse('2014-04-15 17:00:00') }
+      it { expect(Event.oldest.created_at).to eq Time.zone.parse('2013-11-01 17:00:00') }
     end
 
     context 'timespan strict' do
-      it { Event.newest(strict: true).created_at.should eq Time.zone.parse('2014-04-15 17:00:00') }
-      it { Event.oldest(strict: true).created_at.should eq Time.zone.parse('2013-11-01 17:00:00') }
+      it { expect(Event.newest(strict: true).created_at).to eq Time.zone.parse('2014-04-15 17:00:00') }
+      it { expect(Event.oldest(strict: true).created_at).to eq Time.zone.parse('2013-11-01 17:00:00') }
     end
 
     context 'alternative field' do
-      it { Event.newest(field: 'created_at').created_at.should eq Time.zone.parse('2014-04-15 17:00:00') }
-      it { Event.oldest(field: 'created_at').created_at.should eq Time.zone.parse('2013-11-01 17:00:00') }
+      it { expect(Event.newest(field: 'created_at').created_at).to eq Time.zone.parse('2014-04-15 17:00:00') }
+      it { expect(Event.oldest(field: 'created_at').created_at).to eq Time.zone.parse('2013-11-01 17:00:00') }
     end
 
     context 'with default scope' do
-      it { Appointment.newest(field: 'created_at').created_at.should eq Time.zone.parse('2014-04-01 17:00:00') }
-      it { Appointment.oldest(field: 'created_at').created_at.should eq Time.zone.parse('2013-11-01 17:00:00') }
+      it { expect(Appointment.newest(field: 'created_at').created_at).to eq Time.zone.parse('2014-04-01 17:00:00') }
+      it { expect(Appointment.oldest(field: 'created_at').created_at).to eq Time.zone.parse('2013-11-01 17:00:00') }
     end
 
     context 'with scope as a query criteria' do
-      it { Post.newest(field: 'created_at', scope: Post.where(day_of_month: 5)).created_at.should eq Time.zone.parse('2014-01-05 17:00:00') }
-      it { Post.oldest(field: 'created_at', scope: Post.where(day_of_month: 5)).created_at.should eq Time.zone.parse('2013-12-05 17:00:00') }
+      it { expect(Post.newest(field: 'created_at', scope: Post.where(day_of_month: 5)).created_at).to eq Time.zone.parse('2014-01-05 17:00:00') }
+      it { expect(Post.oldest(field: 'created_at', scope: Post.where(day_of_month: 5)).created_at).to eq Time.zone.parse('2013-12-05 17:00:00') }
     end
 
     context 'with scope as a proc' do
-      it { Post.newest(field: 'created_at', scope: ->{ where(day_of_month: 5) }).created_at.should eq Time.zone.parse('2014-01-05 17:00:00') }
-      it { Post.oldest(field: 'created_at', scope: ->{ where(day_of_month: 5) }).created_at.should eq Time.zone.parse('2013-12-05 17:00:00') }
+      it { expect(Post.newest(field: 'created_at', scope: ->{ where(day_of_month: 5) }).created_at).to eq Time.zone.parse('2014-01-05 17:00:00') }
+      it { expect(Post.oldest(field: 'created_at', scope: ->{ where(day_of_month: 5) }).created_at).to eq Time.zone.parse('2013-12-05 17:00:00') }
     end
   end
 
@@ -120,34 +120,34 @@ shared_examples_for 'by direction' do
 
     context 'point-in-time' do
       subject { Post.where(created_at: Time.zone.parse('2014-01-10 17:00:00')).first }
-      it{ subject.previous.created_at.should eq Time.zone.parse('2014-01-05 17:00:00') }
-      it{ subject.next.created_at.should eq Time.zone.parse('2014-01-12 17:00:00') }
+      it{ expect(subject.previous.created_at).to eq Time.zone.parse('2014-01-05 17:00:00') }
+      it{ expect(subject.next.created_at).to eq Time.zone.parse('2014-01-12 17:00:00') }
     end
 
     context 'timespan' do
       subject { Event.where(start_time: Time.zone.parse('2014-01-05 17:00:00')).first }
-      it{ subject.previous.start_time.should eq Time.zone.parse('2013-12-31 17:00:00') }
-      it{ subject.next.start_time.should eq Time.zone.parse('2014-01-07 17:00:00') }
+      it{ expect(subject.previous.start_time).to eq Time.zone.parse('2013-12-31 17:00:00') }
+      it{ expect(subject.next.start_time).to eq Time.zone.parse('2014-01-07 17:00:00') }
     end
 
     context 'with default scope' do
       subject { Appointment.where(created_at: Time.zone.parse('2014-01-05 17:00:00')).first }
-      it{ subject.previous.created_at.should eq Time.zone.parse('2014-01-01 17:00:00') }
-      it{ subject.next.created_at.should eq Time.zone.parse('2014-02-01 17:00:00') }
+      it{ expect(subject.previous.created_at).to eq Time.zone.parse('2014-01-01 17:00:00') }
+      it{ expect(subject.next.created_at).to eq Time.zone.parse('2014-02-01 17:00:00') }
     end
 
     context 'with scope as a query criteria' do
       subject { Post.where(created_at: Time.zone.parse('2014-01-05 17:00:00')).first }
-      it{ subject.previous({ scope: Post.where(day_of_month: 5) }).created_at.should eq Time.zone.parse('2013-12-05 17:00:00')  }
-      it{ subject.next({ scope: Post.where(day_of_month: 1) }).created_at.should eq Time.zone.parse('2014-02-01 17:00:00')  }
+      it{ expect(subject.previous({ scope: Post.where(day_of_month: 5) }).created_at).to eq Time.zone.parse('2013-12-05 17:00:00')  }
+      it{ expect(subject.next({ scope: Post.where(day_of_month: 1) }).created_at).to eq Time.zone.parse('2014-02-01 17:00:00')  }
     end
 
     context 'with scope as a proc' do
       subject { Post.where(created_at: Time.zone.parse('2014-01-05 17:00:00')).first }
-      it{ subject.previous({ scope: Proc.new{ where(day_of_month: 5) } }).created_at.should eq Time.zone.parse('2013-12-05 17:00:00') }
-      it{ subject.previous({ scope: Proc.new{|record| where(day_of_month: record.day_of_month) } }).created_at.should eq Time.zone.parse('2013-12-05 17:00:00') }
-      it{ subject.next({ scope: ->{ where(day_of_month: 1) } }).created_at.should eq Time.zone.parse('2014-02-01 17:00:00') }
-      it{ subject.next({ scope: ->(record){ where(day_of_month: record.day_of_month - 4) } }).created_at.should eq Time.zone.parse('2014-02-01 17:00:00') }
+      it{ expect(subject.previous({ scope: Proc.new{ where(day_of_month: 5) } }).created_at).to eq Time.zone.parse('2013-12-05 17:00:00') }
+      it{ expect(subject.previous({ scope: Proc.new{|record| where(day_of_month: record.day_of_month) } }).created_at).to eq Time.zone.parse('2013-12-05 17:00:00') }
+      it{ expect(subject.next({ scope: ->{ where(day_of_month: 1) } }).created_at).to eq Time.zone.parse('2014-02-01 17:00:00') }
+      it{ expect(subject.next({ scope: ->(record){ where(day_of_month: record.day_of_month - 4) } }).created_at).to eq Time.zone.parse('2014-02-01 17:00:00') }
     end
   end
 end

--- a/spec/integration/shared/by_fortnight.rb
+++ b/spec/integration/shared/by_fortnight.rb
@@ -6,43 +6,43 @@ shared_examples_for 'by fortnight' do
 
     context 'point-in-time' do
       subject { Post.by_fortnight('2014-01-01') }
-      its(:count){ should eq 5 }
+      it { expect(subject.count).to eql(5) }
     end
 
     context 'timespan' do
       subject { Event.by_fortnight(0) }
-      its(:count){ should eq 7 }
+      it { expect(subject.count).to eql(7) }
     end
 
     context 'timespan strict' do
       subject { Event.by_fortnight(Date.parse('2014-01-01'), strict: true) }
-      its(:count){ should eq 0 }
+      it { expect(subject.count).to eql(0) }
     end
 
     context 'with :year option' do
 
       context 'point-in-time' do
         subject { Post.by_fortnight(26, year: 2013) }
-        its(:count){ should eq 6 }
+        it { expect(subject.count).to eql(6) }
       end
 
       context 'timespan' do
         subject { Event.by_fortnight(26, year: 2013) }
-        its(:count){ should eq 7 }
+        it { expect(subject.count).to eql(7) }
       end
 
       context 'timespan strict' do
         subject { Event.by_fortnight(26, year: 2013, strict: true) }
-        its(:count){ should eq 1 }
+        it { expect(subject.count).to eql(1) }
       end
     end
 
     it 'should raise an error when given an invalid argument' do
-      lambda { Post.by_fortnight(27) }.should raise_error(ByStar::ParseError, 'Fortnight number must be between 0 and 26')
+      expect { Post.by_fortnight(27) }.to raise_error(ByStar::ParseError, 'Fortnight number must be between 0 and 26')
     end
 
     it 'should be able to use an alternative field' do
-      Event.by_fortnight(:field => 'end_time').count.should eq 5
+      expect(Event.by_fortnight(:field => 'end_time').count).to eq 5
     end
   end
 end

--- a/spec/integration/shared/by_month.rb
+++ b/spec/integration/shared/by_month.rb
@@ -6,45 +6,45 @@ shared_examples_for 'by month' do
 
     context 'point-in-time' do
       subject { Post.by_month('Feb') }
-      its(:count){ should eq 2 }
+      it { expect(subject.count).to eql(2) }
     end
 
     context 'timespan' do
       subject { Event.by_month(1) }
-      its(:count){ should eq 9 }
+      it { expect(subject.count).to eql(9) }
     end
 
     context 'timespan strict' do
       subject { Event.by_month(Date.parse('2014-02-01'), strict: true) }
-      its(:count){ should eq 1 }
+      it { expect(subject.count).to eql(1) }
     end
 
     context 'with :year option' do
 
       context 'point-in-time' do
         subject { Post.by_month(12, year: 2013) }
-        its(:count){ should eq 8 }
+        it { expect(subject.count).to eql(8) }
       end
 
       context 'timespan' do
         subject { Event.by_month('December', year: 2013) }
-        its(:count){ should eq 12 }
+        it { expect(subject.count).to eql(12) }
       end
 
       context 'timespan strict' do
         subject { Event.by_month('Dec', year: 2013, strict: true) }
-        its(:count){ should eq 4 }
+        it { expect(subject.count).to eql(4) }
       end
     end
 
     it 'should raise an error when given an invalid argument' do
-      ->{ Post.by_month(0) }.should raise_error(ByStar::ParseError, 'Month must be a number between 1 and 12 or a month name')
-      ->{ Post.by_month(13) }.should raise_error(ByStar::ParseError, 'Month must be a number between 1 and 12 or a month name')
-      ->{ Post.by_month('foobar') }.should raise_error(ByStar::ParseError, 'Month must be a number between 1 and 12 or a month name')
+      expect{ Post.by_month(0) }.to raise_error(ByStar::ParseError, 'Month must be a number between 1 and 12 or a month name')
+      expect{ Post.by_month(13) }.to raise_error(ByStar::ParseError, 'Month must be a number between 1 and 12 or a month name')
+      expect{ Post.by_month('foobar') }.to raise_error(ByStar::ParseError, 'Month must be a number between 1 and 12 or a month name')
     end
 
     it 'should be able to use an alternative field' do
-      Event.by_month(:field => 'end_time').count.should eq 8
+      expect(Event.by_month(:field => 'end_time').count).to eq 8
     end
   end
 end

--- a/spec/integration/shared/by_quarter.rb
+++ b/spec/integration/shared/by_quarter.rb
@@ -6,44 +6,44 @@ shared_examples_for 'by quarter' do
 
     context 'point-in-time' do
       subject { Post.by_quarter(2) }
-      its(:count){ should eq 2 }
+      it { expect(subject.count).to eql(2) }
     end
 
     context 'timespan' do
       subject { Event.by_quarter(1) }
-      its(:count){ should eq 13 }
+      it { expect(subject.count).to eql(13) }
     end
 
     context 'timespan strict' do
       subject { Event.by_quarter(Date.parse('2014-02-01'), strict: true) }
-      its(:count){ should eq 7 }
+      it { expect(subject.count).to eql(7) }
     end
 
     context 'with :year option' do
 
       context 'point-in-time' do
         subject { Post.by_quarter(4, year: 2013) }
-        its(:count){ should eq 10 }
+        it { expect(subject.count).to eql(10) }
       end
 
       context 'timespan' do
         subject { Event.by_quarter(4, year: 2013) }
-        its(:count){ should eq 13 }
+        it { expect(subject.count).to eql(13) }
       end
 
       context 'timespan strict' do
         subject { Event.by_quarter(4, year: 2013, strict: true) }
-        its(:count){ should eq 8 }
+        it { expect(subject.count).to eql(8) }
       end
     end
 
     it 'should raise an error when given an invalid argument' do
-      ->{ Post.by_quarter(0) }.should raise_error(ByStar::ParseError, 'Quarter number must be between 1 and 4')
-      ->{ Post.by_quarter(5) }.should raise_error(ByStar::ParseError, 'Quarter number must be between 1 and 4')
+      expect{ Post.by_quarter(0) }.to raise_error(ByStar::ParseError, 'Quarter number must be between 1 and 4')
+      expect{ Post.by_quarter(5) }.to raise_error(ByStar::ParseError, 'Quarter number must be between 1 and 4')
     end
 
     it 'should be able to use an alternative field' do
-      Event.by_quarter(1, :field => 'end_time').count.should eq 12
+      expect(Event.by_quarter(1, :field => 'end_time').count).to eq 12
     end
   end
 end

--- a/spec/integration/shared/by_week.rb
+++ b/spec/integration/shared/by_week.rb
@@ -6,49 +6,49 @@ shared_examples_for 'by week' do
 
     context 'point-in-time' do
       subject { Post.by_week('2014-01-02') }
-      its(:count){ should eq 4 }
+      it { expect(subject.count).to eql(4) }
     end
 
     context 'timespan' do
       subject { Event.by_week(0) }
-      its(:count){ should eq 7 }
+      it { expect(subject.count).to eql(7) }
     end
 
     context 'timespan strict' do
       subject { Event.by_week(Date.parse('2014-01-01'), strict: true) }
-      its(:count){ should eq 0 }
+      it { expect(subject.count).to eql(0) }
     end
 
     context 'with :year option' do
 
       context 'point-in-time' do
         subject { Post.by_week(52, year: 2013) }
-        its(:count){ should eq 4 }
+        it { expect(subject.count).to eql(4) }
       end
 
       context 'timespan' do
         subject { Event.by_week(52, year: 2013) }
-        its(:count){ should eq 7 }
+        it { expect(subject.count).to eql(7) }
       end
 
       context 'timespan strict' do
         subject { Event.by_week(52, year: 2013, strict: true) }
-        its(:count){ should eq 0 }
+        it { expect(subject.count).to eql(0) }
       end
     end
 
     it 'should raise an error when given an invalid argument' do
-      lambda { Post.by_weekend(-1) }.should raise_error(ByStar::ParseError, 'Week number must be between 0 and 52')
-      lambda { Post.by_weekend(53) }.should raise_error(ByStar::ParseError, 'Week number must be between 0 and 52')
+      expect { Post.by_weekend(-1) }.to raise_error(ByStar::ParseError, 'Week number must be between 0 and 52')
+      expect { Post.by_weekend(53) }.to raise_error(ByStar::ParseError, 'Week number must be between 0 and 52')
     end
 
     it 'should be able to use an alternative field' do
-      Event.by_week(:field => 'end_time').count.should eq 3
+      expect(Event.by_week(:field => 'end_time').count).to eq 3
     end
 
     context ':start_day option' do
       subject { Post.by_week('2014-01-02', :start_day => :thursday) }
-      its(:count){ should eq 1 }
+      it { expect(subject.count).to eql(1) }
     end
   end
 end

--- a/spec/integration/shared/by_weekend.rb
+++ b/spec/integration/shared/by_weekend.rb
@@ -6,44 +6,44 @@ shared_examples_for 'by weekend' do
 
     context 'point-in-time' do
       subject { Post.by_weekend('2014-01-01') }
-      its(:count){ should eq 1 }
+      it { expect(subject.count).to eql(1) }
     end
 
     context 'timespan' do
       subject { Event.by_weekend(0) }
-      its(:count){ should eq 5 }
+      it { expect(subject.count).to eql(5) }
     end
 
     context 'timespan strict' do
       subject { Event.by_weekend(Date.parse('2014-01-01'), strict: true) }
-      its(:count){ should eq 0 }
+      it { expect(subject.count).to eql(0) }
     end
 
     context 'with :year option' do
 
       context 'point-in-time' do
         subject { Post.by_weekend(52, year: 2013) }
-        its(:count){ should eq 1 }
+        it { expect(subject.count).to eql(1) }
       end
 
       context 'timespan' do
         subject { Event.by_weekend(52, year: 2013) }
-        its(:count){ should eq 5 }
+        it { expect(subject.count).to eql(5) }
       end
 
       context 'timespan strict' do
         subject { Event.by_weekend(52, year: 2013, strict: true) }
-        its(:count){ should eq 0 }
+        it { expect(subject.count).to eql(0) }
       end
     end
 
     it 'should raise an error when given an invalid argument' do
-      lambda { Post.by_weekend(-1) }.should raise_error(ByStar::ParseError, 'Week number must be between 0 and 52')
-      lambda { Post.by_weekend(53) }.should raise_error(ByStar::ParseError, 'Week number must be between 0 and 52')
+      expect { Post.by_weekend(-1) }.to raise_error(ByStar::ParseError, 'Week number must be between 0 and 52')
+      expect { Post.by_weekend(53) }.to raise_error(ByStar::ParseError, 'Week number must be between 0 and 52')
     end
 
     it 'should be able to use an alternative field' do
-      Event.by_weekend(:field => 'end_time').count.should eq 1
+      expect(Event.by_weekend(:field => 'end_time').count).to eq 1
     end
   end
 end

--- a/spec/integration/shared/by_year.rb
+++ b/spec/integration/shared/by_year.rb
@@ -6,43 +6,43 @@ shared_examples_for 'by year' do
 
     context 'point-in-time' do
       subject { Post.by_year('2014') }
-      its(:count){ should eq 12 }
+      it { expect(subject.count).to eql(12) }
     end
 
     context 'timespan' do
       subject { Event.by_year(13) }
-      its(:count){ should eq 13 }
+      it { expect(subject.count).to eql(13) }
     end
 
     context 'timespan strict' do
       subject { Event.by_year(Date.parse('2014-02-01'), strict: true) }
-      its(:count){ should eq 9 }
+      it { expect(subject.count).to eql(9) }
     end
 
     context 'with :year option' do
 
       context 'point-in-time' do
         subject { Post.by_year(year: 2013) }
-        its(:count){ should eq 10 }
+        it { expect(subject.count).to eql(10) }
       end
 
       context 'timespan' do
         subject { Event.by_year(year: 2014) }
-        its(:count){ should eq 14 }
+        it { expect(subject.count).to eql(14) }
       end
 
       context 'timespan strict' do
         subject { Event.by_year(year: 2013, strict: true) }
-        its(:count){ should eq 8 }
+        it { expect(subject.count).to eql(8) }
       end
     end
 
     it 'should be able to use an alternative field' do
-      Event.by_year(:field => 'end_time').count.should eq 14
+      expect(Event.by_year(:field => 'end_time').count).to eq 14
     end
 
     it 'can use a 2-digit year' do
-      Post.by_year(13).count.should eq 10
+      expect(Post.by_year(13).count).to eq 10
     end
   end
 end

--- a/spec/integration/shared/offset_parameter.rb
+++ b/spec/integration/shared/offset_parameter.rb
@@ -4,28 +4,28 @@ shared_examples_for 'offset parameter' do
 
   describe 'offset' do
     it 'should memoize the offset variable' do
-      Event.instance_variable_get(:@by_star_offset).should eq 3.hours
-      Post.instance_variable_get(:@by_star_offset).should be_nil
+      expect(Event.instance_variable_get(:@by_star_offset)).to eq 3.hours
+      expect(Post.instance_variable_get(:@by_star_offset)).to be_nil
     end
 
     context 'between_times with default offset' do
       subject { Event.between_times(Time.parse('2014-01-01'), Time.parse('2014-01-10')) }
-      its(:count) { should eq 7 }
+      it { expect(subject.count).to eql(7) }
     end
 
     context 'between_times with offset override' do
       subject { Event.between_times(Time.parse('2014-01-01'), Time.parse('2014-01-10'), offset: 16.hours) }
-      its(:count) { should eq 7 }
+      it { expect(subject.count).to eql(7) }
     end
 
     context 'by_day with default offset' do
       subject { Event.by_day(Time.parse('2014-01-01')) }
-      its(:count) { should eq 5 }
+      it { expect(subject.count).to eql(5) }
     end
 
     context 'by_day with offset override' do
       subject { Event.by_day(Time.parse('2014-12-26'), field: :start_time, offset: 5.hours) }
-      its(:count) { should eq 0 }
+      it { expect(subject.count).to eql(0) }
     end
   end
 end

--- a/spec/integration/shared/relative.rb
+++ b/spec/integration/shared/relative.rb
@@ -5,170 +5,170 @@ shared_examples_for 'relative' do
   describe '#past_day' do
     context 'point-in-time' do
       subject { Post.past_day }
-      its(:count){ should eq 1 }
+      it { expect(subject.count).to eql(1) }
     end
 
     context 'timespan' do
       subject { Event.past_day }
-      its(:count){ should eq 5 }
+      it { expect(subject.count).to eql(5) }
     end
 
     context 'timespan strict' do
       subject { Event.past_day(strict: true) }
-      its(:count){ should eq 0 }
+      it { expect(subject.count).to eql(0) }
     end
   end
 
   describe '#past_week' do
     context 'point-in-time' do
       subject { Post.past_week }
-      its(:count){ should eq 3 }
+      it { expect(subject.count).to eql(3) }
     end
 
     context 'timespan' do
       subject { Event.past_week }
-      its(:count){ should eq 7 }
+      it { expect(subject.count).to eql(7) }
     end
 
     context 'timespan strict' do
       subject { Event.past_week(strict: true) }
-      its(:count){ should eq 0 }
+      it { expect(subject.count).to eql(0) }
     end
   end
 
   describe '#past_fortnight' do
     context 'point-in-time' do
       subject { Post.past_fortnight }
-      its(:count){ should eq 4 }
+      it { expect(subject.count).to eql(4) }
     end
 
     context 'timespan' do
       subject { Event.past_fortnight }
-      its(:count){ should eq 8 }
+      it { expect(subject.count).to eql(8) }
     end
 
     context 'timespan strict' do
       subject { Event.past_fortnight(strict: true) }
-      its(:count){ should eq 1 }
+      it { expect(subject.count).to eql(1) }
     end
   end
 
   describe '#past_month' do
     context 'point-in-time' do
       subject { Post.past_month }
-      its(:count){ should eq 8 }
+      it { expect(subject.count).to eql(8) }
     end
 
     context 'timespan' do
       subject { Event.past_month }
-      its(:count){ should eq 12 }
+      it { expect(subject.count).to eql(12) }
     end
 
     context 'timespan strict' do
       subject { Event.past_month(strict: true) }
-      its(:count){ should eq 4 }
+      it { expect(subject.count).to eql(4) }
     end
   end
 
   describe '#past_year' do
     context 'point-in-time' do
       subject { Post.past_year }
-      its(:count){ should eq 10 }
+      it { expect(subject.count).to eql(10) }
     end
 
     context 'timespan' do
       subject { Event.past_year }
-      its(:count){ should eq 13 }
+      it { expect(subject.count).to eql(13) }
     end
 
     context 'timespan strict' do
       subject { Event.past_year(strict: true) }
-      its(:count){ should eq 8 }
+      it { expect(subject.count).to eql(8) }
     end
   end
 
   describe '#next_day' do
     context 'point-in-time' do
       subject { Post.next_day }
-      its(:count){ should eq 2 }
+      it { expect(subject.count).to eql(2) }
     end
 
     context 'timespan' do
       subject { Event.next_day }
-      its(:count){ should eq 5 }
+      it { expect(subject.count).to eql(5) }
     end
 
     context 'timespan strict' do
       subject { Event.next_day(strict: true) }
-      its(:count){ should eq 0 }
+      it { expect(subject.count).to eql(0) }
     end
   end
 
   describe '#next_week' do
     context 'point-in-time' do
       subject { Post.next_week }
-      its(:count){ should eq 3 }
+      it { expect(subject.count).to eql(3) }
     end
 
     context 'timespan' do
       subject { Event.next_week }
-      its(:count){ should eq 7 }
+      it { expect(subject.count).to eql(7) }
     end
 
     context 'timespan strict' do
       subject { Event.next_week(strict: true) }
-      its(:count){ should eq 0 }
+      it { expect(subject.count).to eql(0) }
     end
   end
 
   describe '#next_fortnight' do
     context 'point-in-time' do
       subject { Post.next_fortnight }
-      its(:count){ should eq 5 }
+      it { expect(subject.count).to eql(5) }
     end
 
     context 'timespan' do
       subject { Event.next_fortnight }
-      its(:count){ should eq 7 }
+      it { expect(subject.count).to eql(7) }
     end
 
     context 'timespan strict' do
       subject { Event.next_fortnight(strict: true) }
-      its(:count){ should eq 0 }
+      it { expect(subject.count).to eql(0) }
     end
   end
 
   describe '#next_month' do
     context 'point-in-time' do
       subject { Post.next_month }
-      its(:count){ should eq 6 }
+      it { expect(subject.count).to eql(6) }
     end
 
     context 'timespan' do
       subject { Event.next_month }
-      its(:count){ should eq 9 }
+      it { expect(subject.count).to eql(9) }
     end
 
     context 'timespan strict' do
       subject { Event.next_month(strict: true) }
-      its(:count){ should eq 3 }
+      it { expect(subject.count).to eql(3) }
     end
   end
 
   describe '#next_year' do
     context 'point-in-time' do
       subject { Post.next_year }
-      its(:count){ should eq 12 }
+      it { expect(subject.count).to eql(12) }
     end
 
     context 'timespan' do
       subject { Event.next_year }
-      its(:count){ should eq 14 }
+      it { expect(subject.count).to eql(14) }
     end
 
     context 'timespan strict' do
       subject { Event.next_year(strict: true) }
-      its(:count){ should eq 9 }
+      it { expect(subject.count).to eql(9) }
     end
   end
 end

--- a/spec/integration/shared/scope_parameter.rb
+++ b/spec/integration/shared/scope_parameter.rb
@@ -4,69 +4,69 @@ shared_examples_for 'scope parameter' do
 
   describe 'scope' do
     it 'should memoize the scope variable' do
-      Event.instance_variable_get(:@by_star_scope).should be_nil
-      Post.instance_variable_get(:@by_star_scope).should be_nil
-      Appointment.instance_variable_get(:@by_star_scope).should be_a Proc
+      expect(Event.instance_variable_get(:@by_star_scope)).to be_nil
+      expect(Post.instance_variable_get(:@by_star_scope)).to be_nil
+      expect(Appointment.instance_variable_get(:@by_star_scope)).to be_a Proc
     end
 
     context 'between_times with default scope' do
       subject { Appointment.between_times(Date.parse('2013-12-01'), Date.parse('2014-02-01')) }
-      its(:count) { should eq 3 }
+      it { expect(subject.count).to eql(3) }
     end
 
     context 'between_times with scope override as a query criteria' do
       subject { Appointment.between_times(Date.parse('2013-12-01'), Date.parse('2014-02-01'), scope: Appointment.unscoped) }
-      its(:count) { should eq 14 }
+      it { expect(subject.count).to eql(14) }
     end
 
     context 'between_times with scope override as a Lambda' do
       subject { Appointment.between_times(Date.parse('2013-12-01'), Date.parse('2014-02-01'), scope: ->{ unscoped }) }
-      its(:count) { should eq 14 }
+      it { expect(subject.count).to eql(14) }
     end
 
     context 'between_times with scope override as a Lambda' do
       subject { Appointment.between_times(Date.parse('2013-12-01'), Date.parse('2014-02-01'), scope: ->(x){ unscoped }) }
-      it{ ->{subject}.should raise_error }
+      it{ expect{ subject }.to raise_error }
     end
 
     context 'between_times with scope override as a Proc with arguments' do
       subject { Appointment.between_times(Date.parse('2013-12-01'), Date.parse('2014-02-01'), scope: Proc.new{ unscoped }) }
-      its(:count) { should eq 14 }
+      it { expect(subject.count).to eql(14) }
     end
 
     context 'between_times with scope override as a Proc with arguments' do
       subject { Appointment.between_times(Date.parse('2013-12-01'), Date.parse('2014-02-01'), scope: Proc.new{|x,y| unscoped }) }
-      it{ ->{subject}.should raise_error }
+      it{ expect{ subject }.to raise_error }
     end
 
     context 'by_month with default scope' do
       subject { Appointment.by_month(Date.parse('2014-01-01')) }
-      its(:count) { should eq 2 }
+      it { expect(subject.count).to eql(2) }
     end
 
     context 'by_month with scope override as a query criteria' do
       subject { Appointment.by_month(Date.parse('2014-01-01'), scope: Appointment.unscoped) }
-      its(:count) { should eq 6 }
+      it { expect(subject.count).to eql(6) }
     end
 
     context 'by_month with scope override as a Lambda' do
       subject { Appointment.by_month(Date.parse('2014-01-01'), scope: ->{ unscoped }) }
-      its(:count) { should eq 6 }
+      it { expect(subject.count).to eql(6) }
     end
 
     context 'by_month with scope override as a Lambda with arguments' do
       subject { Appointment.by_month(Date.parse('2014-01-01'), scope: ->(x){ unscoped }) }
-      it{ ->{subject}.should raise_error }
+      it{ expect{ subject }.to raise_error }
     end
 
     context 'by_month with scope override as a Proc' do
       subject { Appointment.by_month(Date.parse('2014-01-01'), scope: Proc.new{ unscoped }) }
-      its(:count) { should eq 6 }
+      it { expect(subject.count).to eql(6) }
     end
 
     context 'by_month with scope override as a Proc with arguments' do
       subject { Appointment.by_month(Date.parse('2014-01-01'), scope: Proc.new{|x| unscoped }) }
-      it{ ->{subject}.should raise_error }
+      it{ expect{ subject }.to raise_error }
     end
   end
 end

--- a/spec/unit/kernel_date_spec.rb
+++ b/spec/unit/kernel_date_spec.rb
@@ -8,12 +8,12 @@ describe Date do
 
     before do
       stub_const('Date', Class.new)
-      Date.any_instance.stub(:to_time_in_current_zone)
+      allow_any_instance_of(Date).to receive(:to_time_in_current_zone)
     end
 
     context 'when #in_time_zone is already defined' do
       before do
-        Date.any_instance.should_receive(:in_time_zone)
+        expect_any_instance_of(Date).to receive(:in_time_zone)
       end
 
       context 'when ByStar::Kernel::Date included' do
@@ -22,7 +22,7 @@ describe Date do
         end
 
         it 'should not be aliased to #to_time_in_current_zone' do
-          subject.should_not_receive(:to_time_in_current_zone)
+          expect(subject).not_to receive(:to_time_in_current_zone)
           subject.in_time_zone
         end
       end
@@ -30,7 +30,7 @@ describe Date do
       context 'when ByStar::Kernel::Date not included' do
 
         it 'should not be aliased to #to_time_in_current_zone' do
-          subject.should_not_receive(:to_time_in_current_zone)
+          expect(subject).not_to receive(:to_time_in_current_zone)
           subject.in_time_zone
         end
       end
@@ -44,7 +44,7 @@ describe Date do
         end
 
         it 'should be aliased to #to_time_in_current_zone' do
-          subject.should_receive(:to_time_in_current_zone)
+          expect(subject).to receive(:to_time_in_current_zone)
           subject.in_time_zone
         end
       end
@@ -52,7 +52,7 @@ describe Date do
       context 'when ByStar::Kernel::Date not included' do
 
         it 'should raise NoMethodError' do
-          ->{ subject.in_time_zone }.should raise_error(NoMethodError)
+          expect{ subject.in_time_zone }.to raise_error(NoMethodError)
         end
       end
     end

--- a/spec/unit/kernel_time_spec.rb
+++ b/spec/unit/kernel_time_spec.rb
@@ -7,8 +7,8 @@ describe Time do
     (0..6).each do |n|
       context "Monday plus #{n} days" do
         subject { Time.zone.parse('2014-01-06') + n.days }
-        its(:beginning_of_weekend){ should eq Time.zone.parse('2014-01-10 15:00') }
-        its(:end_of_weekend){ should eq Time.zone.parse('2014-01-13 02:00').end_of_hour }
+        it { expect(subject.beginning_of_weekend).to eq Time.zone.parse('2014-01-10 15:00') }
+        it { expect(subject.end_of_weekend).to eq Time.zone.parse('2014-01-13 02:00').end_of_hour }
       end
     end
   end
@@ -17,26 +17,26 @@ describe Time do
 
     context 'first day of year' do
       subject { Time.zone.parse '2014-01-01' }
-      its(:beginning_of_fortnight){ should eq Time.zone.parse('2014-01-01') }
-      its(:end_of_fortnight){ should eq Time.zone.parse('2014-01-14').end_of_day }
+      it { expect(subject.beginning_of_fortnight).to eq Time.zone.parse('2014-01-01') }
+      it { expect(subject.end_of_fortnight).to eq Time.zone.parse('2014-01-14').end_of_day }
     end
 
     context 'second fortnight of year' do
       subject { Time.zone.parse '2014-01-16' }
-      its(:beginning_of_fortnight){ should eq Time.zone.parse('2014-01-15') }
-      its(:end_of_fortnight){ should eq Time.zone.parse('2014-01-28').end_of_day }
+      it { expect(subject.beginning_of_fortnight).to eq Time.zone.parse('2014-01-15') }
+      it { expect(subject.end_of_fortnight).to eq Time.zone.parse('2014-01-28').end_of_day }
     end
 
     context 'middle of year' do
       subject { Time.zone.parse '2014-06-13' }
-      its(:beginning_of_fortnight){ should eq Time.zone.parse('2014-06-04') }
-      its(:end_of_fortnight){ should eq Time.zone.parse('2014-06-17').end_of_day }
+      it { expect(subject.beginning_of_fortnight).to eq Time.zone.parse('2014-06-04') }
+      it { expect(subject.end_of_fortnight).to eq Time.zone.parse('2014-06-17').end_of_day }
     end
 
     context 'last day of year' do
       subject { Time.zone.parse '2014-12-31' }
-      its(:beginning_of_fortnight){ should eq Time.zone.parse('2014-12-31') }
-      its(:end_of_fortnight){ should eq Time.zone.parse('2015-01-13').end_of_day }
+      it { expect(subject.beginning_of_fortnight).to eq Time.zone.parse('2014-12-31') }
+      it { expect(subject.end_of_fortnight).to eq Time.zone.parse('2015-01-13').end_of_day }
     end
   end
 
@@ -45,13 +45,13 @@ describe Time do
     subject { Time.zone.parse '2014-01-01' }
 
     context 'week begins Monday' do
-      its(:beginning_of_calendar_month){ should eq Time.zone.parse('2013-12-30') }
-      its(:end_of_calendar_month){ should eq Time.zone.parse('2014-02-02').end_of_day }
+      it { expect(subject.beginning_of_calendar_month).to eq Time.zone.parse('2013-12-30') }
+      it { expect(subject.end_of_calendar_month).to eq Time.zone.parse('2014-02-02').end_of_day }
     end
 
     context 'week begins Sunday' do
-      it { subject.beginning_of_calendar_month(:sunday).should eq Time.zone.parse('2013-12-29') }
-      it { subject.end_of_calendar_month(:sunday).should eq Time.zone.parse('2014-02-01').end_of_day }
+      it { expect(subject.beginning_of_calendar_month(:sunday)).to eq Time.zone.parse('2013-12-29') }
+      it { expect(subject.end_of_calendar_month(:sunday)).to eq Time.zone.parse('2014-02-01').end_of_day }
     end
   end
 end

--- a/spec/unit/normalization_spec.rb
+++ b/spec/unit/normalization_spec.rb
@@ -40,7 +40,7 @@ describe ByStar::Normalization do
 
       context 'natural language String' do
         let(:input){ 'tomorrow at noon' }
-        it { ->{subject}.should raise_error(ByStar::ParseError, "Cannot parse String #{input.inspect}") }
+        it { expect{ subject }.to raise_error(ByStar::ParseError, "Cannot parse String #{input.inspect}") }
       end
     end
   end
@@ -48,17 +48,17 @@ describe ByStar::Normalization do
   shared_examples_for 'time normalization from date/time' do
     context 'Date' do
       let(:input){ Date.parse('2014-01-01') }
-      it { should eq Time.zone.parse('2014-01-01 00:00:00') }
+      it { expect eq Time.zone.parse('2014-01-01 00:00:00') }
     end
 
     context 'DateTime' do
       let(:input){ Time.zone.parse('2014-01-01 15:00:00').to_datetime }
-      it { should eq Time.zone.parse('2014-01-01 15:00:00') }
+      it { expect eq Time.zone.parse('2014-01-01 15:00:00') }
     end
 
     context 'Time' do
       let(:input){ Time.zone.parse('2014-01-01 15:00:00') }
-      it { should eq Time.zone.parse('2014-01-01 15:00:00') }
+      it { expect eq Time.zone.parse('2014-01-01 15:00:00') }
     end
   end
 
@@ -75,12 +75,12 @@ describe ByStar::Normalization do
 
     context 'Fixnum 0' do
       let(:input){ 0 }
-      it { should eq Time.zone.parse('2014-01-01 00:00:00') }
+      it { expect eq Time.zone.parse('2014-01-01 00:00:00') }
     end
 
     context 'Fixnum 20' do
       let(:input){ 20 }
-      it { should eq Time.zone.parse('2014-05-21 00:00:00') }
+      it { expect eq Time.zone.parse('2014-05-21 00:00:00') }
     end
 
     context 'with year option' do
@@ -88,12 +88,12 @@ describe ByStar::Normalization do
 
       context 'Fixnum 0' do
         let(:input){ 0 }
-        it { should eq Time.zone.parse('2011-01-01 00:00:00') }
+        it { expect eq Time.zone.parse('2011-01-01 00:00:00') }
       end
 
       context 'Fixnum 20' do
         let(:input){ 20 }
-        it { should eq Time.zone.parse('2011-05-21 00:00:00') }
+        it { expect eq Time.zone.parse('2011-05-21 00:00:00') }
       end
     end
   end
@@ -105,17 +105,17 @@ describe ByStar::Normalization do
 
     context 'Fixnum 0' do
       let(:input){ 0 }
-      it { should eq Time.zone.parse('2014-01-01 00:00:00') }
+      it { expect eq Time.zone.parse('2014-01-01 00:00:00') }
     end
 
     context 'Fixnum 26' do
       let(:input){ 26 }
-      it { should eq Time.zone.parse('2014-12-31 00:00:00') }
+      it { expect eq Time.zone.parse('2014-12-31 00:00:00') }
     end
 
     context 'out of range' do
-      specify { ->{ ByStar::Normalization.fortnight(-1) }.should raise_error(ByStar::ParseError, 'Fortnight number must be between 0 and 26') }
-      specify { ->{ ByStar::Normalization.fortnight(27) }.should raise_error(ByStar::ParseError, 'Fortnight number must be between 0 and 26') }
+      specify { expect{ ByStar::Normalization.fortnight(-1) }.to raise_error(ByStar::ParseError, 'Fortnight number must be between 0 and 26') }
+      specify { expect{ ByStar::Normalization.fortnight(27) }.to raise_error(ByStar::ParseError, 'Fortnight number must be between 0 and 26') }
     end
 
     context 'with year option' do
@@ -123,12 +123,12 @@ describe ByStar::Normalization do
 
       context 'Fixnum 0' do
         let(:input){ 0 }
-        it { should eq Time.zone.parse('2011-01-01 00:00:00') }
+        it { expect eq Time.zone.parse('2011-01-01 00:00:00') }
       end
 
       context 'Fixnum 26' do
         let(:input){ 26 }
-        it { should eq Time.zone.parse('2011-12-31 00:00:00') }
+        it { expect eq Time.zone.parse('2011-12-31 00:00:00') }
       end
     end
   end
@@ -139,27 +139,27 @@ describe ByStar::Normalization do
 
     context 'month abbr String' do
       let(:input){ 'Feb' }
-      it { should eq Time.zone.parse('2014-02-01 00:00:00') }
+      it { expect eq Time.zone.parse('2014-02-01 00:00:00') }
     end
 
     context 'month full String' do
       let(:input){ 'February' }
-      it { should eq Time.zone.parse('2014-02-01 00:00:00') }
+      it { expect eq Time.zone.parse('2014-02-01 00:00:00') }
     end
 
     context 'number String' do
       let(:input){ '2' }
-      it { should eq Time.zone.parse('2014-02-01 00:00:00') }
+      it { expect eq Time.zone.parse('2014-02-01 00:00:00') }
     end
 
     context 'Fixnum' do
       let(:input){ 2 }
-      it { should eq Time.zone.parse('2014-02-01 00:00:00') }
+      it { expect eq Time.zone.parse('2014-02-01 00:00:00') }
     end
 
     context 'out of range' do
-      specify { ->{ ByStar::Normalization.month(0) }.should raise_error(ByStar::ParseError, 'Month must be a number between 1 and 12 or a month name') }
-      specify { ->{ ByStar::Normalization.month(13) }.should raise_error(ByStar::ParseError, 'Month must be a number between 1 and 12 or a month name') }
+      specify { expect{ ByStar::Normalization.month(0) }.to raise_error(ByStar::ParseError, 'Month must be a number between 1 and 12 or a month name') }
+      specify { expect{ ByStar::Normalization.month(13) }.to raise_error(ByStar::ParseError, 'Month must be a number between 1 and 12 or a month name') }
     end
 
     context 'with year option' do
@@ -167,12 +167,12 @@ describe ByStar::Normalization do
 
       context 'month abbr String' do
         let(:input){ 'Dec' }
-        it { should eq Time.zone.parse('2011-12-01 00:00:00') }
+        it { expect eq Time.zone.parse('2011-12-01 00:00:00') }
       end
 
       context 'Fixnum 12' do
         let(:input){ 10 }
-        it { should eq Time.zone.parse('2011-10-01 00:00:00') }
+        it { expect eq Time.zone.parse('2011-10-01 00:00:00') }
       end
     end
   end
@@ -184,22 +184,22 @@ describe ByStar::Normalization do
 
     context 'Fixnum 1' do
       let(:input){ 1 }
-      it { should eq Time.zone.parse('2014-01-01 00:00:00') }
+      it { expect eq Time.zone.parse('2014-01-01 00:00:00') }
     end
 
     context 'Fixnum 2' do
       let(:input){ 2 }
-      it { should eq Time.zone.parse('2014-04-01 00:00:00') }
+      it { expect eq Time.zone.parse('2014-04-01 00:00:00') }
     end
 
     context 'Fixnum 3' do
       let(:input){ 3 }
-      it { should eq Time.zone.parse('2014-07-01 00:00:00') }
+      it { expect eq Time.zone.parse('2014-07-01 00:00:00') }
     end
 
     context 'Fixnum 4' do
       let(:input){ 4 }
-      it { should eq Time.zone.parse('2014-10-01 00:00:00') }
+      it { expect eq Time.zone.parse('2014-10-01 00:00:00') }
     end
 
     context 'with year option' do
@@ -207,13 +207,13 @@ describe ByStar::Normalization do
 
       context 'Fixnum 3' do
         let(:input){ 3 }
-        it { should eq Time.zone.parse('2011-07-01 00:00:00') }
+        it { expect eq Time.zone.parse('2011-07-01 00:00:00') }
       end
     end
 
     context 'out of range' do
-      specify { ->{ ByStar::Normalization.quarter(0) }.should raise_error(ByStar::ParseError, 'Quarter number must be between 1 and 4') }
-      specify { ->{ ByStar::Normalization.quarter(5) }.should raise_error(ByStar::ParseError, 'Quarter number must be between 1 and 4') }
+      specify { expect{ ByStar::Normalization.quarter(0) }.to raise_error(ByStar::ParseError, 'Quarter number must be between 1 and 4') }
+      specify { expect{ ByStar::Normalization.quarter(5) }.to raise_error(ByStar::ParseError, 'Quarter number must be between 1 and 4') }
     end
   end
 
@@ -224,32 +224,32 @@ describe ByStar::Normalization do
 
     context 'Fixnum 69' do
       let(:input){ 69 }
-      it { should eq Time.zone.parse('2069-01-01 00:00:00') }
+      it { expect eq Time.zone.parse('2069-01-01 00:00:00') }
     end
 
     context 'Fixnum 99' do
       let(:input){ 99 }
-      it { should eq Time.zone.parse('1999-01-01 00:00:00') }
+      it { expect eq Time.zone.parse('1999-01-01 00:00:00') }
     end
 
     context 'Fixnum 2001' do
       let(:input){ 1 }
-      it { should eq Time.zone.parse('2001-01-01 00:00:00') }
+      it { expect eq Time.zone.parse('2001-01-01 00:00:00') }
     end
 
     context 'String 01' do
       let(:input){ '01' }
-      it { should eq Time.zone.parse('2001-01-01 00:00:00') }
+      it { expect eq Time.zone.parse('2001-01-01 00:00:00') }
     end
 
     context 'String 70' do
       let(:input){ '70' }
-      it { should eq Time.zone.parse('1970-01-01 00:00:00') }
+      it { expect eq Time.zone.parse('1970-01-01 00:00:00') }
     end
 
     context 'String 2001' do
       let(:input){ '2001' }
-      it { should eq Time.zone.parse('2001-01-01 00:00:00') }
+      it { expect eq Time.zone.parse('2001-01-01 00:00:00') }
     end
   end
 end


### PR DESCRIPTION
This updates all the specs to the new RSpec syntax and removes all deprecations from RSpec.

I don't have Mongoid installed so didn't run those tests (I'll wait for Travis there), but sqlite and ActiveRecord are green.
