### PR TITLE
Various fixes and improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+before_install:
+  - gem update --system
+  - gem update bundler
+
 before_script:
   - "mysql -e 'create database by_star_test;'"
   - "psql -c 'create database by_star_test;' -U postgres"

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,15 +30,13 @@ branches:
 rvm:
   - 1.9.3
   - 2.0.0
-  - 2.1.5
-  - 2.2.0
+  - 2.1.9
+  - 2.2.5
+  - 2.3.1
   - rbx
   - jruby
 
 matrix:
-  exclude:
-    - rvm: 2.2.0
-      gemfile: spec/gemfiles/Gemfile.rails32
   allow_failures:
     - rvm: rbx
     - rvm: jruby

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v2.2.2 - Unreleased
 
+* Remove arbitrarily silly logic of `#by_weekend` and make it just use Saturday and Sunday only - @johnnyshields
+* Add fortnight, weekend, and calendar_month kernel methods to Date class - @johnnyshields
+* Add `#by_cweek` scope - @johnnyshields
 * Mongoid `newest`, `oldest`, `previous`, and `next` now use `reorder` to ignore any default scope, consistent with ActiveRecord - @johnnyshields
 * Mongoid 3.x: Add support for `Criteria#reorder` method from version 4+ - @johnnyshields
 * Upgrade Rspec tests to version 3.1 - @nhocki

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v2.2.2 - Unreleased
 
+* Deprecate the `:order` option of ByStar queries, as the same can be achieved by using the order method of ActiveRecord - @johnnyshields
 * Remove arbitrarily silly logic of `#by_weekend` and make it just use Saturday and Sunday only - @johnnyshields
 * Add fortnight, weekend, and calendar_month kernel methods to Date class - @johnnyshields
 * Add `#by_cweek` scope - @johnnyshields

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ See sections below for detailed argument usage of each:
 * `by_day`
 * `by_week` Allows zero-based week value from 0 to 52
 * `by_cweek` Allows one-based week value from 1 to 53
-* `by_weekend` 60-hour period from 15:00 Friday to 03:00 Monday
+* `by_weekend` Saturday and Sunday only of the given week
 * `by_fortnight` A two-week period, with the first fortnight of the year beginning on 1st January
 * `by_month`
 * `by_calendar_month` Month as it appears on a calendar; days form previous/following months which are part of the first/last weeks of the given month
@@ -426,7 +426,7 @@ You may pass in a `:start_day` option (`:monday`, `:tuesday`, etc.) to specify t
 
 ### by_weekend
 
-If the time passed in (or the time now is a weekend) it will return posts from 12am Saturday to 11:59:59PM Sunday. If the time is a week day, it will show all posts for the coming weekend.
+If the time passed in (or the time now is a weekend) it will return posts from 0:00 Saturday to 23:59:59 Sunday. If the time is a week day, it will show all posts for the coming weekend.
 
 ```ruby
    Post.by_weekend(Time.now)

--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ ByStar adds additional shortcut scopes based on commonly used time ranges.
 See sections below for detailed argument usage of each:
 
 * `by_day`
-* `by_week`
+* `by_week` Allows zero-based week value from 0 to 52
+* `by_cweek` Allows one-based week value from 1 to 53
 * `by_weekend` 60-hour period from 15:00 Friday to 03:00 Monday
 * `by_fortnight` A two-week period, with the first fortnight of the year beginning on 1st January
 * `by_month`
@@ -389,35 +390,37 @@ This will return all posts in the 18th fortnight week of 2012.
 
 This will return all posts from the first fortnight of 2012.
 
-### by_week
+### by_week and by_cweek
 
-Week numbering starts at 0. The beginning of a week is Monday, 12am.
+Week numbering starts at 0, and cweek numbering starts at 1 (same as `Date#cweek`). The beginning of a week is as defined in `ActiveSupport#beginning_of_week`, which can be configured.
 
 To find records from the current week:
 
 ```ruby
    Post.by_week
+   Post.by_cweek  # same result
 ```
 
-To find records based on a week, you can pass in a number (representing the week number) or a time object:
+This will return all posts in the 37th week of the current year (remember week numbering starts at 0):
 
 ```ruby
    Post.by_week(36)
+   Post.by_cweek(37)  # same result
 ```
 
-This will return all posts in the 37th week of the current year (remember week numbering starts at 0).
+This will return all posts in the 37th week of 2012:
 
 ```ruby
    Post.by_week(36, :year => 2012)
+   Post.by_cweek(37, :year => 2012)  # same result
 ```
 
-This will return all posts in the 37th week of 2012.
+This will return all posts in the week which contains Jan 1, 2012:
 
 ```ruby
    Post.by_week(Time.local(2012,1,1))
+   Post.by_cweek(Time.local(2012,1,1))  # same result
 ```
-
-This will return all posts from the first week of 2012.
 
 You may pass in a `:start_day` option (`:monday`, `:tuesday`, etc.) to specify the starting day of the week. This may also be configured in Rails.
 

--- a/by_star.gemspec
+++ b/by_star.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "activerecord"
   s.add_development_dependency "mongoid"
   s.add_development_dependency "pg"
-  s.add_development_dependency "mysql2"
+  s.add_development_dependency "mysql2", ">= 0.4.4"
   s.add_development_dependency "rspec-rails", "~> 3.1"
   s.add_development_dependency "timecop", "~> 0.3"
   s.add_development_dependency "pry"

--- a/by_star.gemspec
+++ b/by_star.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "activerecord"
   s.add_development_dependency "mongoid"
   s.add_development_dependency "pg"
-  s.add_development_dependency "mysql2", ">= 0.4.4"
+  s.add_development_dependency "mysql2", "~> 0.3.10"
   s.add_development_dependency "rspec-rails", "~> 3.1"
   s.add_development_dependency "timecop", "~> 0.3"
   s.add_development_dependency "pry"

--- a/by_star.gemspec
+++ b/by_star.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.add_dependency "activesupport"
 
   s.add_development_dependency "chronic"
-  s.add_development_dependency "bundler", ">= 1.0.0"
+  s.add_development_dependency "bundler"
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "activerecord"
   s.add_development_dependency "mongoid"

--- a/lib/by_star/between.rb
+++ b/lib/by_star/between.rb
@@ -22,6 +22,12 @@ module ByStar
       end
     end
 
+    def by_cweek(*args)
+      with_by_star_options(*args) do |time, options|
+        by_week(ByStar::Normalization.cweek(time, options), options)
+      end
+    end
+
     def by_weekend(*args)
       with_by_star_options(*args) do |time, options|
         time = ByStar::Normalization.week(time, options)

--- a/lib/by_star/kernel/date.rb
+++ b/lib/by_star/kernel/date.rb
@@ -12,6 +12,37 @@ module ByStar
           alias_method :in_time_zone, :to_time_in_current_zone
         end
       end
+
+      # A "Weekend" is defined as beginning of Saturday to end of Sunday.
+      # The weekend for a given date will be the the next weekend if the day Mon-Thurs,
+      # otherwise the current weekend if the day is Fri-Sun.
+      def beginning_of_weekend
+        beginning_of_week(:monday).advance(:days => 5)
+      end
+
+      def end_of_weekend
+        beginning_of_weekend + 1
+      end
+
+      # A "Fortnight" is defined as a two week period, with the first fortnight of the
+      # year beginning on 1st January.
+      def beginning_of_fortnight
+        beginning_of_year + 14 * ((self - beginning_of_year) / 14).to_i
+      end
+
+      def end_of_fortnight
+        beginning_of_fortnight + 13
+      end
+
+      # A "Calendar Month" is defined as a month as it appears on a calendar, including days form
+      # previous/following months which are part of the first/last weeks of the given month.
+      def beginning_of_calendar_month(*args)
+        beginning_of_month.beginning_of_week(*args)
+      end
+
+      def end_of_calendar_month(*args)
+        end_of_month.end_of_week(*args)
+      end
     end
   end
 end

--- a/lib/by_star/kernel/time.rb
+++ b/lib/by_star/kernel/time.rb
@@ -4,15 +4,15 @@ module ByStar
 
     module Time
 
-      # A "Weekend" is defined as the 60-hour period from 15:00 Friday to 03:00 Monday.
+      # A "Weekend" is defined as beginning of Saturday to end of Sunday.
       # The weekend for a given date will be the the next weekend if the day Mon-Thurs,
       # otherwise the current weekend if the day is Fri-Sun.
       def beginning_of_weekend
-        beginning_of_week(:monday).advance(:days => 4) + 15.hours
+        beginning_of_week(:monday).advance(:days => 5)
       end
 
       def end_of_weekend
-        (beginning_of_weekend + 59.hours).end_of_hour
+        (beginning_of_weekend + 47.hours).end_of_hour
       end
 
       # A "Fortnight" is defined as a two week period, with the first fortnight of the

--- a/lib/by_star/normalization.rb
+++ b/lib/by_star/normalization.rb
@@ -42,6 +42,15 @@ module ByStar
         time.beginning_of_year + value.to_i.weeks
       end
 
+      def cweek(value, options={})
+        _value = value
+        if _value.is_a?(Fixnum)
+          raise ParseError, 'cweek number must be between 1 and 53' unless value.in?(1..53)
+          _value -= 1
+        end
+        week(_value, options)
+      end
+
       def fortnight(value, options={})
         value = try_string_to_int(value)
         case value

--- a/lib/by_star/orm/mongoid/by_star.rb
+++ b/lib/by_star/orm/mongoid/by_star.rb
@@ -19,7 +19,7 @@ module Mongoid
         else
           scope.gt(end_field => start).lt(start_field => finish)
         end
-        scope = scope.order_by(field => options[:order]) if options[:order]
+        scope = scope.order_by(start_field => options[:order]) if options[:order]
         scope
       end
 

--- a/spec/integration/active_record/active_record_spec.rb
+++ b/spec/integration/active_record/active_record_spec.rb
@@ -27,6 +27,7 @@ describe ActiveRecord do
   it_behaves_like 'by calendar month'
   it_behaves_like 'by quarter'
   it_behaves_like 'by week'
+  it_behaves_like 'by cweek'
   it_behaves_like 'by weekend'
   it_behaves_like 'by year'
   it_behaves_like 'relative'

--- a/spec/integration/active_record/active_record_spec.rb
+++ b/spec/integration/active_record/active_record_spec.rb
@@ -12,7 +12,7 @@ describe ActiveRecord do
     end
 
     ActiveRecord::Base.configurations = db_config
-    ActiveRecord::Base.establish_connection(ENV['DB'] || 'sqlite')
+    ActiveRecord::Base.establish_connection(ENV['DB'] || :sqlite)
     load File.dirname(__FILE__) + '/../../fixtures/active_record/schema.rb'
     load File.dirname(__FILE__) + '/../../fixtures/active_record/models.rb'
     load File.dirname(__FILE__) + '/../../fixtures/shared/seeds.rb'

--- a/spec/integration/active_record/active_record_spec.rb
+++ b/spec/integration/active_record/active_record_spec.rb
@@ -34,19 +34,29 @@ describe ActiveRecord do
   it_behaves_like 'offset parameter'
   it_behaves_like 'scope parameter'
 
-  it 'should be able to order the result set' do
-    scope = Post.by_year(Time.zone.now.year, :order => 'created_at DESC')
-    expect(scope.order_values).to eq ['created_at DESC']
-  end
-
   describe '#between_times' do
-    subject { Post.between_times(Time.parse('2014-01-01'), Time.parse('2014-01-06')) }
+    subject { Post.between_times(Time.zone.parse('2014-01-01'), Time.zone.parse('2014-01-06')) }
     it { expect be_a(ActiveRecord::Relation) }
     it { expect(subject.count).to eql(3) }
+
+    context ':order option' do
+
+      it 'should be able to order the result set asc' do
+        scope = Post.by_year(Time.zone.now.year, :order => 'created_at ASC')
+        expect(scope.order_values).to eq ['created_at ASC']
+        expect(scope.first.created_at).to eq Time.zone.parse('2014-01-01 17:00:00')
+      end
+
+      it 'should be able to order the result set desc' do
+        scope = Post.by_year(Time.zone.now.year, :order => 'created_at DESC')
+        expect(scope.order_values).to eq ['created_at DESC']
+        expect(scope.first.created_at).to eq Time.zone.parse('2014-04-15 17:00:00')
+      end
+    end
   end
 
   describe '#between' do
-    subject { Post.between(Time.parse('2014-01-01'), Time.parse('2014-01-06')) }
+    subject { Post.between(Time.zone.parse('2014-01-01'), Time.zone.parse('2014-01-06')) }
     it 'should be an alias of #between_times' do
       expect(subject.count).to eql(3)
     end

--- a/spec/integration/mongoid/mongoid_spec.rb
+++ b/spec/integration/mongoid/mongoid_spec.rb
@@ -34,14 +34,29 @@ describe 'Mongoid' do
   it_behaves_like 'scope parameter'
 
   describe '#between_times' do
-    subject { Post.between_times(Time.parse('2014-01-01'), Time.parse('2014-01-06')) }
+    subject { Post.between_times(Time.zone.parse('2014-01-01'), Time.zone.parse('2014-01-06')) }
     it { should be_a(Mongoid::Criteria) }
     it { expect(subject.count).to eql(3) }
+
+    context ':order option' do
+
+      it 'should be able to order the result set asc' do
+        scope = Post.by_year(Time.zone.now.year, :order => :asc)
+        expect(scope.options[:sort]).to eq({'created_at' => 1})
+        expect(scope.first.created_at).to eq Time.zone.parse('2014-01-01 17:00:00')
+      end
+
+      it 'should be able to order the result set desc' do
+        scope = Post.by_year(Time.zone.now.year, :order => :desc)
+        expect(scope.options[:sort]).to eq({'created_at' => -1})
+        expect(scope.first.created_at).to eq Time.zone.parse('2014-04-15 17:00:00')
+      end
+    end
   end
 
   describe '#between' do
     it 'should not override Mongoid between method' do
-      posts = Post.between(created_at: Time.parse('2014-01-01')..Time.parse('2014-01-06'))
+      posts = Post.between(created_at: Time.zone.parse('2014-01-01')..Time.zone.parse('2014-01-06'))
       expect(posts.count).to eql(3)
     end
   end

--- a/spec/integration/mongoid/mongoid_spec.rb
+++ b/spec/integration/mongoid/mongoid_spec.rb
@@ -26,6 +26,7 @@ describe 'Mongoid' do
   it_behaves_like 'by calendar month'
   it_behaves_like 'by quarter'
   it_behaves_like 'by week'
+  it_behaves_like 'by cweek'
   it_behaves_like 'by weekend'
   it_behaves_like 'by year'
   it_behaves_like 'relative'

--- a/spec/integration/shared/by_cweek.rb
+++ b/spec/integration/shared/by_cweek.rb
@@ -1,53 +1,53 @@
 require 'spec_helper'
 
-shared_examples_for 'by week' do
+shared_examples_for 'by cweek' do
 
-  describe '#by_week' do
+  describe '#by_cweek' do
 
     context 'point-in-time' do
-      subject { Post.by_week('2014-01-02') }
+      subject { Post.by_cweek('2014-01-02') }
       it { expect(subject.count).to eql(4) }
     end
 
     context 'timespan' do
-      subject { Event.by_week(0) }
+      subject { Event.by_cweek(1) }
       it { expect(subject.count).to eql(7) }
     end
 
     context 'timespan strict' do
-      subject { Event.by_week(Date.parse('2014-01-01'), strict: true) }
+      subject { Event.by_cweek(Date.parse('2014-01-01'), strict: true) }
       it { expect(subject.count).to eql(0) }
     end
 
     context 'with :year option' do
 
       context 'point-in-time' do
-        subject { Post.by_week(52, year: 2013) }
+        subject { Post.by_cweek(53, year: 2013) }
         it { expect(subject.count).to eql(4) }
       end
 
       context 'timespan' do
-        subject { Event.by_week(52, year: 2013) }
+        subject { Event.by_cweek(53, year: 2013) }
         it { expect(subject.count).to eql(7) }
       end
 
       context 'timespan strict' do
-        subject { Event.by_week(52, year: 2013, strict: true) }
+        subject { Event.by_cweek(53, year: 2013, strict: true) }
         it { expect(subject.count).to eql(0) }
       end
     end
 
     it 'should raise an error when given an invalid argument' do
-      expect { Post.by_week(-1) }.to raise_error(ByStar::ParseError, 'Week number must be between 0 and 52')
-      expect { Post.by_week(53) }.to raise_error(ByStar::ParseError, 'Week number must be between 0 and 52')
+      expect { Post.by_cweek(0) }.to raise_error(ByStar::ParseError, 'cweek number must be between 1 and 53')
+      expect { Post.by_cweek(54) }.to raise_error(ByStar::ParseError, 'cweek number must be between 1 and 53')
     end
 
     it 'should be able to use an alternative field' do
-      expect(Event.by_week(:field => 'end_time').count).to eq 3
+      expect(Event.by_cweek(:field => 'end_time').count).to eq 3
     end
 
     context ':start_day option' do
-      subject { Post.by_week('2014-01-02', :start_day => :thursday) }
+      subject { Post.by_cweek('2014-01-02', :start_day => :thursday) }
       it { expect(subject.count).to eql(1) }
     end
   end

--- a/spec/integration/shared/by_day.rb
+++ b/spec/integration/shared/by_day.rb
@@ -9,7 +9,7 @@ shared_examples_for 'by day' do
     end
 
     context 'timespan' do
-      it { expect(Event.by_day(Time.parse '2014-01-01').count).to eql(5) }
+      it { expect(Event.by_day(Time.zone.parse '2014-01-01').count).to eql(5) }
     end
 
     context 'timespan strict' do

--- a/spec/integration/shared/by_direction.rb
+++ b/spec/integration/shared/by_direction.rb
@@ -10,7 +10,7 @@ shared_examples_for 'by direction' do
     end
 
     context 'timespan' do
-      subject { Event.before(Time.parse '2014-01-05') }
+      subject { Event.before(Time.zone.parse '2014-01-05') }
       it { expect(subject.count).to eql(13) }
     end
 

--- a/spec/integration/shared/offset_parameter.rb
+++ b/spec/integration/shared/offset_parameter.rb
@@ -9,22 +9,22 @@ shared_examples_for 'offset parameter' do
     end
 
     context 'between_times with default offset' do
-      subject { Event.between_times(Time.parse('2014-01-01'), Time.parse('2014-01-10')) }
+      subject { Event.between_times(Time.zone.parse('2014-01-01'), Time.zone.parse('2014-01-10')) }
       it { expect(subject.count).to eql(7) }
     end
 
     context 'between_times with offset override' do
-      subject { Event.between_times(Time.parse('2014-01-01'), Time.parse('2014-01-10'), offset: 16.hours) }
+      subject { Event.between_times(Time.zone.parse('2014-01-01'), Time.zone.parse('2014-01-10'), offset: 16.hours) }
       it { expect(subject.count).to eql(7) }
     end
 
     context 'by_day with default offset' do
-      subject { Event.by_day(Time.parse('2014-01-01')) }
+      subject { Event.by_day(Time.zone.parse('2014-01-01')) }
       it { expect(subject.count).to eql(5) }
     end
 
     context 'by_day with offset override' do
-      subject { Event.by_day(Time.parse('2014-12-26'), field: :start_time, offset: 5.hours) }
+      subject { Event.by_day(Time.zone.parse('2014-12-26'), field: :start_time, offset: 5.hours) }
       it { expect(subject.count).to eql(0) }
     end
   end

--- a/spec/integration/shared/scope_parameter.rb
+++ b/spec/integration/shared/scope_parameter.rb
@@ -26,7 +26,7 @@ shared_examples_for 'scope parameter' do
 
     context 'between_times with scope override as a Lambda' do
       subject { Appointment.between_times(Date.parse('2013-12-01'), Date.parse('2014-02-01'), scope: ->(x){ unscoped }) }
-      it{ expect{ subject }.to raise_error }
+      it{ expect{ subject }.to raise_error(RuntimeError, 'ByStar :scope does not accept arguments') }
     end
 
     context 'between_times with scope override as a Proc with arguments' do
@@ -36,7 +36,7 @@ shared_examples_for 'scope parameter' do
 
     context 'between_times with scope override as a Proc with arguments' do
       subject { Appointment.between_times(Date.parse('2013-12-01'), Date.parse('2014-02-01'), scope: Proc.new{|x,y| unscoped }) }
-      it{ expect{ subject }.to raise_error }
+      it{ expect{ subject }.to raise_error(RuntimeError, 'ByStar :scope does not accept arguments') }
     end
 
     context 'by_month with default scope' do
@@ -56,7 +56,7 @@ shared_examples_for 'scope parameter' do
 
     context 'by_month with scope override as a Lambda with arguments' do
       subject { Appointment.by_month(Date.parse('2014-01-01'), scope: ->(x){ unscoped }) }
-      it{ expect{ subject }.to raise_error }
+      it{ expect{ subject }.to raise_error(RuntimeError, 'ByStar :scope does not accept arguments') }
     end
 
     context 'by_month with scope override as a Proc' do
@@ -66,7 +66,7 @@ shared_examples_for 'scope parameter' do
 
     context 'by_month with scope override as a Proc with arguments' do
       subject { Appointment.by_month(Date.parse('2014-01-01'), scope: Proc.new{|x| unscoped }) }
-      it{ expect{ subject }.to raise_error }
+      it{ expect{ subject }.to raise_error(RuntimeError, 'ByStar :scope does not accept arguments') }
     end
   end
 end

--- a/spec/unit/kernel_date_spec.rb
+++ b/spec/unit/kernel_date_spec.rb
@@ -57,4 +57,57 @@ describe Date do
       end
     end
   end
+
+  describe 'weekend' do
+
+    (0..6).each do |n|
+      context "Monday plus #{n} days" do
+        subject { Date.parse('2014-01-06') + n.days }
+        it { expect(subject.beginning_of_weekend).to eq Date.parse('2014-01-11') }
+        it { expect(subject.end_of_weekend).to eq Date.parse('2014-01-12') }
+      end
+    end
+  end
+
+  describe 'fortnight' do
+
+    context 'first day of year' do
+      subject { Date.parse '2014-01-01' }
+      it { expect(subject.beginning_of_fortnight).to eq Date.parse('2014-01-01') }
+      it { expect(subject.end_of_fortnight).to eq Date.parse('2014-01-14') }
+    end
+
+    context 'second fortnight of year' do
+      subject { Date.parse '2014-01-16' }
+      it { expect(subject.beginning_of_fortnight).to eq Date.parse('2014-01-15') }
+      it { expect(subject.end_of_fortnight).to eq Date.parse('2014-01-28') }
+    end
+
+    context 'middle of year' do
+      subject { Date.parse '2014-06-13' }
+      it { expect(subject.beginning_of_fortnight).to eq Date.parse('2014-06-04') }
+      it { expect(subject.end_of_fortnight).to eq Date.parse('2014-06-17') }
+    end
+
+    context 'last day of year' do
+      subject { Date.parse '2014-12-31' }
+      it { expect(subject.beginning_of_fortnight).to eq Date.parse('2014-12-31') }
+      it { expect(subject.end_of_fortnight).to eq Date.parse('2015-01-13') }
+    end
+  end
+
+  describe 'calendar_month' do
+
+    subject { Date.parse '2014-01-01' }
+
+    context 'week begins Monday' do
+      it { expect(subject.beginning_of_calendar_month).to eq Date.parse('2013-12-30') }
+      it { expect(subject.end_of_calendar_month).to eq Date.parse('2014-02-02') }
+    end
+
+    context 'week begins Sunday' do
+      it { expect(subject.beginning_of_calendar_month(:sunday)).to eq Date.parse('2013-12-29') }
+      it { expect(subject.end_of_calendar_month(:sunday)).to eq Date.parse('2014-02-01') }
+    end
+  end
 end

--- a/spec/unit/kernel_time_spec.rb
+++ b/spec/unit/kernel_time_spec.rb
@@ -7,8 +7,8 @@ describe Time do
     (0..6).each do |n|
       context "Monday plus #{n} days" do
         subject { Time.zone.parse('2014-01-06') + n.days }
-        it { expect(subject.beginning_of_weekend).to eq Time.zone.parse('2014-01-10 15:00') }
-        it { expect(subject.end_of_weekend).to eq Time.zone.parse('2014-01-13 02:00').end_of_hour }
+        it { expect(subject.beginning_of_weekend).to eq Time.zone.parse('2014-01-11') }
+        it { expect(subject.end_of_weekend).to eq Time.zone.parse('2014-01-12').end_of_day }
       end
     end
   end

--- a/spec/unit/normalization_spec.rb
+++ b/spec/unit/normalization_spec.rb
@@ -73,6 +73,11 @@ describe ByStar::Normalization do
     it_behaves_like 'time normalization from string'
     it_behaves_like 'time normalization from date/time'
 
+    context 'Fixnum -1' do
+      let(:input){ -1 }
+      it { expect{subject}.to raise_error(ByStar::ParseError) }
+    end
+
     context 'Fixnum 0' do
       let(:input){ 0 }
       it { expect eq Time.zone.parse('2014-01-01 00:00:00') }
@@ -81,6 +86,11 @@ describe ByStar::Normalization do
     context 'Fixnum 20' do
       let(:input){ 20 }
       it { expect eq Time.zone.parse('2014-05-21 00:00:00') }
+    end
+
+    context 'Fixnum 53' do
+      let(:input){ 53 }
+      it { expect{subject}.to raise_error(ByStar::ParseError) }
     end
 
     context 'with year option' do
@@ -93,6 +103,46 @@ describe ByStar::Normalization do
 
       context 'Fixnum 20' do
         let(:input){ 20 }
+        it { expect eq Time.zone.parse('2011-05-21 00:00:00') }
+      end
+    end
+  end
+
+  describe '#cweek' do
+    subject { ByStar::Normalization.cweek(input, options) }
+    it_behaves_like 'time normalization from string'
+    it_behaves_like 'time normalization from date/time'
+
+    context 'Fixnum 9' do
+      let(:input){ 0 }
+      it { expect{subject}.to raise_error(ByStar::ParseError) }
+    end
+
+    context 'Fixnum 1' do
+      let(:input){ 1 }
+      it { expect eq Time.zone.parse('2014-01-01 00:00:00') }
+    end
+
+    context 'Fixnum 21' do
+      let(:input){ 21 }
+      it { expect eq Time.zone.parse('2014-05-21 00:00:00') }
+    end
+
+    context 'Fixnum 54' do
+      let(:input){ 54 }
+      it { expect{subject}.to raise_error(ByStar::ParseError) }
+    end
+
+    context 'with year option' do
+      let(:options){ { :year => 2011 } }
+
+      context 'Fixnum 1' do
+        let(:input){ 1 }
+        it { expect eq Time.zone.parse('2011-01-01 00:00:00') }
+      end
+
+      context 'Fixnum 21' do
+        let(:input){ 21 }
         it { expect eq Time.zone.parse('2011-05-21 00:00:00') }
       end
     end

--- a/spec/unit/normalization_spec.rb
+++ b/spec/unit/normalization_spec.rb
@@ -75,7 +75,7 @@ describe ByStar::Normalization do
 
     context 'Fixnum -1' do
       let(:input){ -1 }
-      it { expect{subject}.to raise_error(ByStar::ParseError) }
+      it { expect{subject}.to raise_error(ByStar::ParseError, 'Week number must be between 0 and 52') }
     end
 
     context 'Fixnum 0' do
@@ -90,7 +90,7 @@ describe ByStar::Normalization do
 
     context 'Fixnum 53' do
       let(:input){ 53 }
-      it { expect{subject}.to raise_error(ByStar::ParseError) }
+      it { expect{subject}.to raise_error(ByStar::ParseError, 'Week number must be between 0 and 52') }
     end
 
     context 'with year option' do
@@ -115,7 +115,7 @@ describe ByStar::Normalization do
 
     context 'Fixnum 9' do
       let(:input){ 0 }
-      it { expect{subject}.to raise_error(ByStar::ParseError) }
+      it { expect{subject}.to raise_error(ByStar::ParseError, 'cweek number must be between 1 and 53') }
     end
 
     context 'Fixnum 1' do
@@ -130,7 +130,7 @@ describe ByStar::Normalization do
 
     context 'Fixnum 54' do
       let(:input){ 54 }
-      it { expect{subject}.to raise_error(ByStar::ParseError) }
+      it { expect{subject}.to raise_error(ByStar::ParseError, 'cweek number must be between 1 and 53') }
     end
 
     context 'with year option' do


### PR DESCRIPTION
- Fixes #58. Adds support for by_cweek.
- Remove arbitrarily silly logic of `#by_weekend` and make it just use Saturday and Sunday only
- Fix between_times :order option for mongoid, improve specs
- Add fortnight, weekend, and calendar_month kernel methods to Date class
- Fix broken Travis (mostly -- mysql still having issues)
