### PR TITLE
3.0.0rc1 initial commit:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## v3.0.0.rc1 - Unreleased
+
+* BREAKING CHANGE - `#between` method has been removed for ActiveRecord (was deprecated in 2.2.0)
+* BREAKING CHANGE - Mongoid `:order` option now requires a Hash arguments in the form { field: direction }, i.e. the same as `Mongoid::Document#order_by`.
+* BREAKING CHANGE - Drop support for option `:year` used as a standalone. Use `by_year` instead.
+* `#between_times now accepts a `Range` as an argument, while continuing to support existing `Time, Time` interface.
+* Timespan "strict" query now sets double-sided constraints on both fields to ensure database indexes are used properly.
+
 ## v2.2.2 - Unreleased
 
 * Deprecate the `:order` option of ByStar queries, as the same can be achieved by using the order method of ActiveRecord - @johnnyshields

--- a/README.md
+++ b/README.md
@@ -217,16 +217,16 @@ If you'd like to confine results to only those both starting and ending within t
 
 In order to ensure query performance on large dataset, you must add an index to the query field (e.g. "created_at") be indexed. ByStar does **not** define indexes automatically.
 
-Database indexes require querying a range ("double-sided") on a single field, i.e. `start_time >= X and start_time <= Y`.
-If we a single-sided query, the database will iterate through all items either from the beginning or until the end of time).
+Database indexes require querying a range query on a single field, i.e. `start_time >= X and start_time <= Y`.
+If we use a single-sided query, the database will iterate through all items either from the beginning or until the end of time.
 This poses a challenge for timespan-type objects which have two fields, i.e. `start_time` and `end_time`.
-There are two cases of timespans to consider:
+There are two cases to consider:
 
-1) Timespan queries with `:strict` option, e.g. "start_time >= X and end_time <= Y".
+1) Timespan with `:strict` option, e.g. "start_time >= X and end_time <= Y".
 
 Given that this gem requires start_time >= end_time, we add the converse constraint "start_time <= Y and end_time >= X" to ensure both fields are double-sided, i.e. an index can be used on either field.
 
-2) Timespan queries without `:strict` option, e.g. "start_time < Y and end_time > X".
+2) Timespan without `:strict` option, e.g. "start_time < Y and end_time > X".
 
 This is not yet supported but will be soon.
 

--- a/lib/by_star/base.rb
+++ b/lib/by_star/base.rb
@@ -41,7 +41,7 @@ module ByStar
         elsif options[:scope_args]
           return instance_exec(*Array(options[:scope_args]), &scope)
         else
-          raise 'ByStar :scope does not accept arguments'
+          raise 'ByStar :scope Proc requires :scope_args to be specified.'
         end
       else
         return scope
@@ -61,9 +61,7 @@ module ByStar
     #
     def with_by_star_options(*args, &block)
       options = args.extract_options!.symbolize_keys!
-      time = args.first
-      time ||= Time.zone.local(options[:year]) if options[:year]
-      time ||= Time.zone.now
+      time = args.first || Time.zone.now
       block.call(time, options)
     end
   end

--- a/lib/by_star/kernel/time.rb
+++ b/lib/by_star/kernel/time.rb
@@ -18,11 +18,11 @@ module ByStar
       # A "Fortnight" is defined as a two week period, with the first fortnight of the
       # year beginning on 1st January.
       def beginning_of_fortnight
-        (beginning_of_year.to_date + 14 * ((self - beginning_of_year) / 2.weeks).to_i).beginning_of_day
+        (beginning_of_year + 1.fortnight * ((self - beginning_of_year) / 1.fortnight).to_i).beginning_of_day
       end
 
       def end_of_fortnight
-        (beginning_of_fortnight.to_date + 13).end_of_day
+        (beginning_of_fortnight + 13.days).end_of_day
       end
 
       # A "Calendar Month" is defined as a month as it appears on a calendar, including days form

--- a/lib/by_star/orm/active_record/by_star.rb
+++ b/lib/by_star/orm/active_record/by_star.rb
@@ -5,29 +5,23 @@ module ByStar
     module ClassMethods
       include ::ByStar::Base
 
-      # Returns all records between a given start and finish time.
-      #
-      # Currently only supports Time objects.
-      def between_times_query(start, finish, options={})
-        start_field = by_star_start_field(options)
-        end_field = by_star_end_field(options)
-
-        scope = by_star_scope(options)
-        scope = if options[:strict] || start_field == end_field
-          scope.where("#{start_field} >= ? AND #{end_field} <= ?", start, finish)
-        else
-          scope.where("#{end_field} > ? AND #{start_field} < ?", start, finish)
-        end
-        scope = scope.order(options[:order]) if options[:order]
-        scope
-      end
-
-      def between(*args)
-        ActiveSupport::Deprecation.warn 'ByStar `between` method will be removed in v3.0.0. Please use `between_times`'
-        between_times(*args)
-      end
-
       protected
+
+      def by_star_point_query(scope, field, range)
+        scope.where("#{field} >= ? AND #{field} <= ?", range.first, range.last)
+      end
+
+      def by_star_span_strict_query(scope, start_field, end_field, range)
+        scope.where("#{start_field} >= ? AND #{start_field} <= ? AND #{end_field} >= ? AND #{end_field} <= ?", range.first, range.last, range.first, range.last)
+      end
+
+      def by_star_span_overlap_query(scope, start_field, end_field, range, options)
+        scope.where("#{end_field} > ? AND #{start_field} < ?", range.first, range.last)
+      end
+
+      def by_star_order(scope, order)
+        scope.order(order)
+      end
 
       def by_star_default_field
         "#{self.table_name}.created_at"

--- a/lib/by_star/orm/mongoid/by_star.rb
+++ b/lib/by_star/orm/mongoid/by_star.rb
@@ -9,19 +9,7 @@ module Mongoid
     module ClassMethods
       include ::ByStar::Base
 
-      def between_times_query(start, finish, options={})
-        start_field = by_star_start_field(options)
-        end_field = by_star_end_field(options)
-
-        scope = by_star_scope(options)
-        scope = if options[:strict] || start_field == end_field
-          scope.gte(start_field => start).lte(end_field => finish)
-        else
-          scope.gt(end_field => start).lt(start_field => finish)
-        end
-        scope = scope.order_by(start_field => options[:order]) if options[:order]
-        scope
-      end
+      protected
 
       def by_star_end_field_with_mongoid(options = {})
         database_field_name by_star_end_field_without_mongoid(options)
@@ -33,10 +21,24 @@ module Mongoid
       end
       alias_method_chain :by_star_start_field, :mongoid
 
-      protected
-
       def by_star_default_field
         :created_at
+      end
+
+      def by_star_point_query(scope, field, range)
+        scope.where(field => range)
+      end
+
+      def by_star_span_strict_query(scope, start_field, end_field, range)
+        scope.where(start_field => range).where(end_field => range)
+      end
+
+      def by_star_span_overlap_query(scope, start_field, end_field, range, options)
+        scope.gt(end_field => range.first).lt(start_field => range.last)
+      end
+
+      def by_star_order(scope, order)
+        scope.order_by(order)
       end
 
       def before_query(time, options={})

--- a/spec/integration/active_record/active_record_spec.rb
+++ b/spec/integration/active_record/active_record_spec.rb
@@ -54,11 +54,4 @@ describe ActiveRecord do
       end
     end
   end
-
-  describe '#between' do
-    subject { Post.between(Time.zone.parse('2014-01-01'), Time.zone.parse('2014-01-06')) }
-    it 'should be an alias of #between_times' do
-      expect(subject.count).to eql(3)
-    end
-  end
 end if testing_active_record?

--- a/spec/integration/mongoid/mongoid_spec.rb
+++ b/spec/integration/mongoid/mongoid_spec.rb
@@ -41,13 +41,13 @@ describe 'Mongoid' do
     context ':order option' do
 
       it 'should be able to order the result set asc' do
-        scope = Post.by_year(Time.zone.now.year, :order => :asc)
+        scope = Post.by_year(Time.zone.now.year, :order => {:created_at => :asc})
         expect(scope.options[:sort]).to eq({'created_at' => 1})
         expect(scope.first.created_at).to eq Time.zone.parse('2014-01-01 17:00:00')
       end
 
       it 'should be able to order the result set desc' do
-        scope = Post.by_year(Time.zone.now.year, :order => :desc)
+        scope = Post.by_year(Time.zone.now.year, :order => {:created_at => :desc})
         expect(scope.options[:sort]).to eq({'created_at' => -1})
         expect(scope.first.created_at).to eq Time.zone.parse('2014-04-15 17:00:00')
       end

--- a/spec/integration/shared/by_year.rb
+++ b/spec/integration/shared/by_year.rb
@@ -19,20 +19,20 @@ shared_examples_for 'by year' do
       it { expect(subject.count).to eql(9) }
     end
 
-    context 'with :year option' do
+    context 'integer' do
 
       context 'point-in-time' do
-        subject { Post.by_year(year: 2013) }
+        subject { Post.by_year(2013) }
         it { expect(subject.count).to eql(10) }
       end
 
       context 'timespan' do
-        subject { Event.by_year(year: 2014) }
+        subject { Event.by_year(2014) }
         it { expect(subject.count).to eql(14) }
       end
 
       context 'timespan strict' do
-        subject { Event.by_year(year: 2013, strict: true) }
+        subject { Event.by_year(2013, strict: true) }
         it { expect(subject.count).to eql(8) }
       end
     end

--- a/spec/integration/shared/offset_parameter.rb
+++ b/spec/integration/shared/offset_parameter.rb
@@ -14,7 +14,7 @@ shared_examples_for 'offset parameter' do
     end
 
     context 'between_times with offset override' do
-      subject { Event.between_times(Time.zone.parse('2014-01-01'), Time.zone.parse('2014-01-10'), offset: 16.hours) }
+      subject { Event.between_times(Time.zone.parse('2014-01-01')..Time.zone.parse('2014-01-10'), offset: 16.hours) }
       it { expect(subject.count).to eql(7) }
     end
 

--- a/spec/integration/shared/scope_parameter.rb
+++ b/spec/integration/shared/scope_parameter.rb
@@ -15,7 +15,7 @@ shared_examples_for 'scope parameter' do
     end
 
     context 'between_times with scope override as a query criteria' do
-      subject { Appointment.between_times(Date.parse('2013-12-01'), Date.parse('2014-02-01'), scope: Appointment.unscoped) }
+      subject { Appointment.between_times(Date.parse('2013-12-01')..Date.parse('2014-02-01'), scope: Appointment.unscoped) }
       it { expect(subject.count).to eql(14) }
     end
 
@@ -25,8 +25,8 @@ shared_examples_for 'scope parameter' do
     end
 
     context 'between_times with scope override as a Lambda' do
-      subject { Appointment.between_times(Date.parse('2013-12-01'), Date.parse('2014-02-01'), scope: ->(x){ unscoped }) }
-      it{ expect{ subject }.to raise_error(RuntimeError, 'ByStar :scope does not accept arguments') }
+      subject { Appointment.between_times(Date.parse('2013-12-01')..Date.parse('2014-02-01'), scope: ->(x){ unscoped }) }
+      it{ expect{ subject }.to raise_error(RuntimeError, 'ByStar :scope Proc requires :scope_args to be specified.') }
     end
 
     context 'between_times with scope override as a Proc with arguments' do
@@ -35,8 +35,8 @@ shared_examples_for 'scope parameter' do
     end
 
     context 'between_times with scope override as a Proc with arguments' do
-      subject { Appointment.between_times(Date.parse('2013-12-01'), Date.parse('2014-02-01'), scope: Proc.new{|x,y| unscoped }) }
-      it{ expect{ subject }.to raise_error(RuntimeError, 'ByStar :scope does not accept arguments') }
+      subject { Appointment.between_times(Date.parse('2013-12-01')..Date.parse('2014-02-01'), scope: Proc.new{|x,y| unscoped }) }
+      it{ expect{ subject }.to raise_error(RuntimeError, 'ByStar :scope Proc requires :scope_args to be specified.') }
     end
 
     context 'by_month with default scope' do
@@ -56,7 +56,7 @@ shared_examples_for 'scope parameter' do
 
     context 'by_month with scope override as a Lambda with arguments' do
       subject { Appointment.by_month(Date.parse('2014-01-01'), scope: ->(x){ unscoped }) }
-      it{ expect{ subject }.to raise_error(RuntimeError, 'ByStar :scope does not accept arguments') }
+      it{ expect{ subject }.to raise_error(RuntimeError, 'ByStar :scope Proc requires :scope_args to be specified.') }
     end
 
     context 'by_month with scope override as a Proc' do
@@ -66,7 +66,7 @@ shared_examples_for 'scope parameter' do
 
     context 'by_month with scope override as a Proc with arguments' do
       subject { Appointment.by_month(Date.parse('2014-01-01'), scope: Proc.new{|x| unscoped }) }
-      it{ expect{ subject }.to raise_error(RuntimeError, 'ByStar :scope does not accept arguments') }
+      it{ expect{ subject }.to raise_error(RuntimeError, 'ByStar :scope Proc requires :scope_args to be specified.') }
     end
   end
 end


### PR DESCRIPTION
* BREAKING CHANGE - `#between` method has been removed for ActiveRecord (was deprecated in 2.2.0)
* BREAKING CHANGE - Mongoid `:order` option now requires a Hash arguments in the form { field: direction }, i.e. the same as `Mongoid::Document#order_by`.
* BREAKING CHANGE - Drop support for option `:year` used as a standalone. Use `by_year` instead.
* `#between_times now accepts a `Range` as an argument, while continuing to support existing `Time, Time` interface.
* Timespan "strict" query now sets double-sided constraints on both fields to ensure database indexes are used properly.