### PR TITLE
between_times one-sided and Array args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@
 * BREAKING CHANGE - `#between` method has been removed for ActiveRecord (was deprecated in 2.2.0)
 * BREAKING CHANGE - Mongoid `:order` option now requires a Hash arguments in the form { field: direction }, i.e. the same as `Mongoid::Document#order_by`.
 * BREAKING CHANGE - Drop support for option `:year` used as a standalone. Use `by_year` instead.
-* `#between_times now accepts a `Range` as an argument, while continuing to support existing `Time, Time` interface.
+* `#between_times` now accepts `Range` or `Array` as an argument, while continuing to support existing `Time, Time` interface.
 * Timespan "strict" query now sets double-sided constraints on both fields to ensure database indexes are used properly.
+* Remove hash rocket syntax. Not considered breaking as Ruby 1.9.3 was already minimum supported version.
 
 ## v2.2.2 - Unreleased
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * BREAKING CHANGE - `#between` method has been removed for ActiveRecord (was deprecated in 2.2.0)
 * BREAKING CHANGE - Mongoid `:order` option now requires a Hash arguments in the form { field: direction }, i.e. the same as `Mongoid::Document#order_by`.
 * BREAKING CHANGE - Drop support for option `:year` used as a standalone. Use `by_year` instead.
+* `#between_times` now accepts one-sided arguments, e.g. `Time, nil` or `nil, Time`.
 * `#between_times` now accepts `Range` or `Array` as an argument, while continuing to support existing `Time, Time` interface.
 * Timespan "strict" query now sets double-sided constraints on both fields to ensure database indexes are used properly.
 * Remove hash rocket syntax. Not considered breaking as Ruby 1.9.3 was already minimum supported version.

--- a/README.md
+++ b/README.md
@@ -45,8 +45,14 @@ ByStar adds the following finder scopes (class methods) to your model to query t
 These accept a `Date`, `Time`, or `DateTime` object as an argument, which defaults to `Time.zone.now` if not specified:
 
 * `between_times(start_time, end_time)` - Finds all records occurring between the two given times.
-* `before(end_time)` - Finds all records occurring before the given time.
-* `after(start_time)` - Finds all records occurring after the given time.
+* `before(end_time)` - Finds all records occurring before the given time
+* `after(start_time)` - Finds all records occurring after the given time
+
+`between_times` supports alternate argument forms:
+   * `between_times(Range)`
+   * `between_times(Array)`
+   * `between_times(start_time, nil)` - same as `after(start_time)`
+   * `between_times(nil, end_time)` - same as `before(end_time)`
 
 ### Time Range Scopes
 

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ class MyModel
 ByStar adds the following finder scopes (class methods) to your model to query time ranges.
 These accept a `Date`, `Time`, or `DateTime` object as an argument, which defaults to `Time.zone.now` if not specified:
 
-* `between_times(start_time, end_time)` Finds all records occurring between the two given times
-* `before(end_time)` Finds all records occurring before the given time
-* `after(start_time)` Finds all records occurring after the given time
+* `between_times(start_time, end_time)` - Finds all records occurring between the two given times.
+* `before(end_time)` - Finds all records occurring before the given time.
+* `after(start_time)` - Finds all records occurring after the given time.
 
 ### Time Range Scopes
 

--- a/lib/by_star/between.rb
+++ b/lib/by_star/between.rb
@@ -5,12 +5,10 @@ module ByStar
     def between_times(*args)
       options = args.extract_options!.symbolize_keys!
 
-      # Do not apply default offset here
       offset = (options[:offset] || 0).seconds
-      range = if args[0].is_a?(Range)
-                (args[0].first + offset)..(args[0].last + offset)
-              else
-                (args[0] + offset)..(args[1] + offset)
+      range = case args[0]
+                when Range, Array then (args[0].first + offset)..(args[0].last + offset)
+                else (args[0] + offset)..(args[1] + offset)
               end
 
       start_field = by_star_start_field(options)

--- a/lib/by_star/between.rb
+++ b/lib/by_star/between.rb
@@ -5,22 +5,29 @@ module ByStar
     def between_times(*args)
       options = args.extract_options!.symbolize_keys!
 
+      start_time, end_time = case args[0]
+                               when Array, Range then [args[0].first, args[0].last]
+                               else args[0..1]
+                             end
+
       offset = (options[:offset] || 0).seconds
-      range = case args[0]
-                when Range, Array then (args[0].first + offset)..(args[0].last + offset)
-                else (args[0] + offset)..(args[1] + offset)
-              end
+      start_time += offset if start_time
+      end_time   += offset if end_time
 
       start_field = by_star_start_field(options)
       end_field = by_star_end_field(options)
       scope = by_star_scope(options)
 
-      scope = if start_field == end_field
-                by_star_point_query(scope, start_field, range)
+      scope = if !end_time
+                by_star_after_query(scope, start_field, start_time)
+              elsif !start_time
+                by_star_before_query(scope, start_field, end_time)
+              elsif start_field == end_field
+                by_star_point_query(scope, start_field, start_time, end_time)
               elsif options[:strict]
-                by_star_span_strict_query(scope, start_field, end_field, range)
+                by_star_span_strict_query(scope, start_field, end_field, start_time, end_time)
               else
-                by_star_span_overlap_query(scope, start_field, end_field, range, options)
+                by_star_span_overlap_query(scope, start_field, end_field, start_time, end_time, options)
               end
 
       scope = by_star_order(scope, options[:order]) if options[:order]

--- a/lib/by_star/directional.rb
+++ b/lib/by_star/directional.rb
@@ -4,16 +4,20 @@ module ByStar
 
     def before(*args)
       with_by_star_options(*args) do |time, options|
+        scope = by_star_scope(options)
+        field = by_star_start_field(options)
         time = ByStar::Normalization.time(time)
-        before_query(time, options)
+        by_star_before_query(scope, field, time)
       end
     end
     alias_method :before_now, :before
 
     def after(*args)
       with_by_star_options(*args) do |time, options|
+        scope = by_star_scope(options)
+        field = by_star_start_field(options)
         time = ByStar::Normalization.time(time)
-        after_query(time, options)
+        by_star_after_query(scope, field, time)
       end
     end
     alias_method :after_now, :after

--- a/lib/by_star/orm/active_record/by_star.rb
+++ b/lib/by_star/orm/active_record/by_star.rb
@@ -7,34 +7,32 @@ module ByStar
 
       protected
 
-      def by_star_point_query(scope, field, range)
-        scope.where("#{field} >= ? AND #{field} <= ?", range.first, range.last)
-      end
-
-      def by_star_span_strict_query(scope, start_field, end_field, range)
-        scope.where("#{start_field} >= ? AND #{start_field} <= ? AND #{end_field} >= ? AND #{end_field} <= ?", range.first, range.last, range.first, range.last)
-      end
-
-      def by_star_span_overlap_query(scope, start_field, end_field, range, options)
-        scope.where("#{end_field} > ? AND #{start_field} < ?", range.first, range.last)
-      end
-
-      def by_star_order(scope, order)
-        scope.order(order)
-      end
-
       def by_star_default_field
         "#{self.table_name}.created_at"
       end
 
-      def before_query(time, options={})
-        field = by_star_start_field(options)
-        by_star_scope(options).where("#{field} <= ?", time)
+      def by_star_point_query(scope, field, start_time, end_time)
+        scope.where("#{field} >= ? AND #{field} <= ?", start_time, end_time)
       end
 
-      def after_query(time, options={})
-        field = by_star_start_field(options)
-        by_star_scope(options).where("#{field} >= ?", time)
+      def by_star_span_strict_query(scope, start_field, end_field, start_time, end_time)
+        scope.where("#{start_field} >= ? AND #{start_field} <= ? AND #{end_field} >= ? AND #{end_field} <= ?", start_time, end_time, start_time, end_time)
+      end
+
+      def by_star_span_overlap_query(scope, start_field, end_field, start_time, end_time, options)
+        scope.where("#{end_field} > ? AND #{start_field} < ?", start_time, end_time)
+      end
+
+      def by_star_before_query(scope, field, time)
+        scope.where("#{field} <= ?", time)
+      end
+
+      def by_star_after_query(scope, field, time)
+        scope.where("#{field} >= ?", time)
+      end
+
+      def by_star_order(scope, order)
+        scope.order(order)
       end
 
       def oldest_query(options={})

--- a/lib/by_star/orm/mongoid/by_star.rb
+++ b/lib/by_star/orm/mongoid/by_star.rb
@@ -25,30 +25,30 @@ module Mongoid
         :created_at
       end
 
-      def by_star_point_query(scope, field, range)
+      def by_star_point_query(scope, field, start_time, end_time)
+        range = start_time..end_time
         scope.where(field => range)
       end
 
-      def by_star_span_strict_query(scope, start_field, end_field, range)
+      def by_star_span_strict_query(scope, start_field, end_field, start_time, end_time)
+        range = start_time..end_time
         scope.where(start_field => range).where(end_field => range)
       end
 
-      def by_star_span_overlap_query(scope, start_field, end_field, range, options)
-        scope.gt(end_field => range.first).lt(start_field => range.last)
+      def by_star_span_overlap_query(scope, start_field, end_field, start_time, end_time, options)
+        scope.gt(end_field => start_time).lt(start_field => end_time)
+      end
+
+      def by_star_before_query(scope, field, time)
+        scope.lte(field => time)
+      end
+
+      def by_star_after_query(scope, field, time)
+        scope.gte(field => time)
       end
 
       def by_star_order(scope, order)
         scope.order_by(order)
-      end
-
-      def before_query(time, options={})
-        field = by_star_start_field(options)
-        by_star_scope(options).lte(field => time)
-      end
-
-      def after_query(time, options={})
-        field = by_star_start_field(options)
-        by_star_scope(options).gte(field => time)
       end
 
       def oldest_query(options={})

--- a/spec/integration/active_record/active_record_spec.rb
+++ b/spec/integration/active_record/active_record_spec.rb
@@ -20,6 +20,10 @@ describe ActiveRecord do
     ActiveRecord::Base.logger = Logger.new(File.dirname(__FILE__) + '/../../tmp/activerecord.log')
   end
 
+  it_behaves_like 'between_times'
+  it_behaves_like 'offset parameter'
+  it_behaves_like 'order parameter'
+  it_behaves_like 'scope parameter'
   it_behaves_like 'by day'
   it_behaves_like 'by direction'
   it_behaves_like 'by fortnight'
@@ -31,27 +35,4 @@ describe ActiveRecord do
   it_behaves_like 'by weekend'
   it_behaves_like 'by year'
   it_behaves_like 'relative'
-  it_behaves_like 'offset parameter'
-  it_behaves_like 'scope parameter'
-
-  describe '#between_times' do
-    subject { Post.between_times(Time.zone.parse('2014-01-01'), Time.zone.parse('2014-01-06')) }
-    it { expect be_a(ActiveRecord::Relation) }
-    it { expect(subject.count).to eql(3) }
-
-    context ':order option' do
-
-      it 'should be able to order the result set asc' do
-        scope = Post.by_year(Time.zone.now.year, order: 'created_at ASC')
-        expect(scope.order_values).to eq ['created_at ASC']
-        expect(scope.first.created_at).to eq Time.zone.parse('2014-01-01 17:00:00')
-      end
-
-      it 'should be able to order the result set desc' do
-        scope = Post.by_year(Time.zone.now.year, order: 'created_at DESC')
-        expect(scope.order_values).to eq ['created_at DESC']
-        expect(scope.first.created_at).to eq Time.zone.parse('2014-04-15 17:00:00')
-      end
-    end
-  end
 end if testing_active_record?

--- a/spec/integration/mongoid/mongoid_spec.rb
+++ b/spec/integration/mongoid/mongoid_spec.rb
@@ -19,6 +19,10 @@ describe 'Mongoid' do
     Mongoid.purge!
   end
 
+  it_behaves_like 'between_times'
+  it_behaves_like 'offset parameter'
+  it_behaves_like 'order parameter'
+  it_behaves_like 'scope parameter'
   it_behaves_like 'by day'
   it_behaves_like 'by direction'
   it_behaves_like 'by fortnight'
@@ -30,34 +34,4 @@ describe 'Mongoid' do
   it_behaves_like 'by weekend'
   it_behaves_like 'by year'
   it_behaves_like 'relative'
-  it_behaves_like 'offset parameter'
-  it_behaves_like 'scope parameter'
-
-  describe '#between_times' do
-    subject { Post.between_times(Time.zone.parse('2014-01-01'), Time.zone.parse('2014-01-06')) }
-    it { should be_a(Mongoid::Criteria) }
-    it { expect(subject.count).to eql(3) }
-
-    context ':order option' do
-
-      it 'should be able to order the result set asc' do
-        scope = Post.by_year(Time.zone.now.year, order: {created_at: :asc})
-        expect(scope.options[:sort]).to eq({'created_at' => 1})
-        expect(scope.first.created_at).to eq Time.zone.parse('2014-01-01 17:00:00')
-      end
-
-      it 'should be able to order the result set desc' do
-        scope = Post.by_year(Time.zone.now.year, order: {created_at: :desc})
-        expect(scope.options[:sort]).to eq({'created_at' => -1})
-        expect(scope.first.created_at).to eq Time.zone.parse('2014-04-15 17:00:00')
-      end
-    end
-  end
-
-  describe '#between' do
-    it 'should not override Mongoid between method' do
-      posts = Post.between(created_at: Time.zone.parse('2014-01-01')..Time.zone.parse('2014-01-06'))
-      expect(posts.count).to eql(3)
-    end
-  end
 end if testing_mongoid?

--- a/spec/integration/shared/between_times.rb
+++ b/spec/integration/shared/between_times.rb
@@ -12,6 +12,48 @@ shared_examples_for 'between_times' do
     end
 
     it { expect(subject.count).to eql(3) }
+
+    context 'one-sided query' do
+
+      context 'point query' do
+
+        context 'only start time' do
+          subject { Post.between_times(Time.zone.parse('2014-01-01'), nil) }
+          it { expect(subject.count).to eql(12) }
+        end
+
+        context 'only end time' do
+          subject { Post.between_times(nil, Time.zone.parse('2014-01-01')) }
+          it { expect(subject.count).to eql(10) }
+        end
+      end
+
+      context 'timespan loose query' do
+
+        context 'only start time' do
+          subject { Event.between_times(Time.zone.parse('2014-01-01'), nil, strict: false) }
+          it { expect(subject.count).to eql(9) }
+        end
+
+        context 'only end time' do
+          subject { Event.between_times(nil, Time.zone.parse('2014-01-01'), strict: false) }
+          it { expect(subject.count).to eql(13) }
+        end
+      end
+
+      context 'timespan strict query' do
+
+        context 'only start time' do
+          subject { Event.between_times(Time.zone.parse('2014-01-01'), nil) }
+          it { expect(subject.count).to eql(9) }
+        end
+
+        context 'only end time' do
+          subject { Event.between_times(nil, Time.zone.parse('2014-01-01')) }
+          it { expect(subject.count).to eql(13) }
+        end
+      end
+    end
   end
 
   if testing_mongoid?

--- a/spec/integration/shared/between_times.rb
+++ b/spec/integration/shared/between_times.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+shared_examples_for 'between_times' do
+
+  describe '#between_times' do
+    subject { Post.between_times(Time.zone.parse('2014-01-01'), Time.zone.parse('2014-01-06')) }
+
+    if testing_active_record?
+      it { is_expected.to be_a(ActiveRecord::Relation) }
+    else testing_mongoid?
+      it { is_expected.to be_a(Mongoid::Criteria) }
+    end
+
+    it { expect(subject.count).to eql(3) }
+  end
+
+  if testing_mongoid?
+    describe '#between' do
+      it 'should not override Mongoid between method' do
+        posts = Post.between(created_at: Time.zone.parse('2014-01-01')..Time.zone.parse('2014-01-06'))
+        expect(posts.count).to eql(3)
+      end
+    end
+  end
+end

--- a/spec/integration/shared/by_direction.rb
+++ b/spec/integration/shared/by_direction.rb
@@ -9,13 +9,18 @@ shared_examples_for 'by direction' do
       it { expect(subject.count).to eql(12) }
     end
 
-    context 'timespan' do
+    context 'timespan default' do
       subject { Event.before(Time.zone.parse '2014-01-05') }
       it { expect(subject.count).to eql(13) }
     end
 
     context 'timespan strict' do
       subject { Event.before('2014-01-05', strict: true) }
+      it { expect(subject.count).to eql(13) }
+    end
+
+    context 'timespan not strict' do
+      subject { Event.before('2014-01-05', strict: false) }
       it { expect(subject.count).to eql(13) }
     end
 
@@ -47,13 +52,18 @@ shared_examples_for 'by direction' do
       it { expect(subject.count).to eql(10) }
     end
 
-    context 'timespan' do
+    context 'timespan default' do
       subject { Event.after(Date.parse '2014-01-05') }
       it { expect(subject.count).to eql(9) }
     end
 
     context 'timespan strict' do
       subject { Event.after('2014-01-05', strict: true) }
+      it { expect(subject.count).to eql(9) }
+    end
+
+    context 'timespan not strict' do
+      subject { Event.after('2014-01-05', strict: false) }
       it { expect(subject.count).to eql(9) }
     end
 

--- a/spec/integration/shared/offset_parameter.rb
+++ b/spec/integration/shared/offset_parameter.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 shared_examples_for 'offset parameter' do
 
-  describe 'offset' do
+  describe ':offset' do
+
     it 'should memoize the offset variable' do
       expect(Event.instance_variable_get(:@by_star_offset)).to eq 3.hours
       expect(Post.instance_variable_get(:@by_star_offset)).to be_nil

--- a/spec/integration/shared/order_parameter.rb
+++ b/spec/integration/shared/order_parameter.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+shared_examples_for 'order parameter' do
+
+  describe ':order' do
+
+    if testing_active_record?
+
+      it 'should be able to order the result set asc' do
+        scope = Post.by_year(Time.zone.now.year, order: 'created_at ASC')
+        expect(scope.order_values).to eq ['created_at ASC']
+        expect(scope.first.created_at).to eq Time.zone.parse('2014-01-01 17:00:00')
+      end
+
+      it 'should be able to order the result set desc' do
+        scope = Post.by_year(Time.zone.now.year, order: 'created_at DESC')
+        expect(scope.order_values).to eq ['created_at DESC']
+        expect(scope.first.created_at).to eq Time.zone.parse('2014-04-15 17:00:00')
+      end
+
+    elsif testing_mongoid?
+
+      it 'should be able to order the result set asc' do
+        scope = Post.by_year(Time.zone.now.year, order: {created_at: :asc})
+        expect(scope.options[:sort]).to eq({'created_at' => 1})
+        expect(scope.first.created_at).to eq Time.zone.parse('2014-01-01 17:00:00')
+      end
+
+      it 'should be able to order the result set desc' do
+        scope = Post.by_year(Time.zone.now.year, order: {created_at: :desc})
+        expect(scope.options[:sort]).to eq({'created_at' => -1})
+        expect(scope.first.created_at).to eq Time.zone.parse('2014-04-15 17:00:00')
+      end
+    end
+  end
+end

--- a/spec/integration/shared/scope_parameter.rb
+++ b/spec/integration/shared/scope_parameter.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 shared_examples_for 'scope parameter' do
 
-  describe 'scope' do
+  describe ':scope' do
+
     it 'should memoize the scope variable' do
       expect(Event.instance_variable_get(:@by_star_scope)).to be_nil
       expect(Post.instance_variable_get(:@by_star_scope)).to be_nil
@@ -20,7 +21,7 @@ shared_examples_for 'scope parameter' do
     end
 
     context 'between_times with scope override as a Lambda' do
-      subject { Appointment.between_times(Date.parse('2013-12-01'), Date.parse('2014-02-01'), scope: ->{ unscoped }) }
+      subject { Appointment.between_times([Date.parse('2013-12-01'), Date.parse('2014-02-01')], scope: ->{ unscoped }) }
       it { expect(subject.count).to eql(14) }
     end
 
@@ -35,7 +36,7 @@ shared_examples_for 'scope parameter' do
     end
 
     context 'between_times with scope override as a Proc with arguments' do
-      subject { Appointment.between_times(Date.parse('2013-12-01')..Date.parse('2014-02-01'), scope: Proc.new{|x,y| unscoped }) }
+      subject { Appointment.between_times([Date.parse('2013-12-01'), Date.parse('2014-02-01')], scope: Proc.new{|x,y| unscoped }) }
       it{ expect{ subject }.to raise_error(RuntimeError, 'ByStar :scope Proc requires :scope_args to be specified.') }
     end
 


### PR DESCRIPTION
Fixes #60

- `#between_times` now accepts one-sided arguments, e.g. `Time, nil` or `nil, Time`.
- Support Array argument to between_times
- Cleanup specs