### PR TITLE
at_time and index scope features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
 * BREAKING CHANGE - Drop support for option `:year` used as a standalone. Use `by_year` instead.
 * `#between_times` now accepts one-sided arguments, e.g. `Time, nil` or `nil, Time`.
 * `#between_times` now accepts `Range` or `Array` as an argument, while continuing to support existing `Time, Time` interface.
+* Add `#at_time` method for point-in-time query.
 * Timespan "strict" query now sets double-sided constraints on both fields to ensure database indexes are used properly.
+* Add optional `:index_scope` option for timespan "non-strict" queries to improve database performance.
 * Remove hash rocket syntax. Not considered breaking as Ruby 1.9.3 was already minimum supported version.
 
 ## v2.2.2 - Unreleased

--- a/UPGRADING
+++ b/UPGRADING
@@ -1,12 +1,4 @@
 Upgrading ByStar
 ----------------
 
-* ActiveRecord: the `between` method has been deprecated as of version 2.2.0, and will be removed in version 3.0.0.
-Please use `between_times` instead.
-
-* Mongoid: the `between` method has been removed as of version 2.2.0, as it conflicts with the native Mongoid `between`
-method. Please use `between_times` instead.
-
-* Chronic gem (used for time string parsing) has been removed as a hard dependency for ByStar,
-however it is still supported. If you would like to use Chronic with ByStar, please explicitly
-include `gem chronic` into your Gemfile.
+* ActiveRecord: the `between` method has been removed as of version 3.0.0. Please use `between_times` instead.

--- a/lib/by_star/base.rb
+++ b/lib/by_star/base.rb
@@ -71,8 +71,7 @@ module ByStar
       value = value.call(start_time, end_time, options) if value.is_a?(Proc)
       case value
         when nil, false then nil
-        when Time then value
-        when DateTime then value.to_time
+        when Time, DateTime then value
         when Date then value.in_time_zone
         when ActiveSupport::Duration then start_time - value
         when Numeric then start_time - value.seconds

--- a/lib/by_star/base.rb
+++ b/lib/by_star/base.rb
@@ -11,6 +11,7 @@ module ByStar
       @by_star_end_field   ||= args[1]
       @by_star_offset      ||= options[:offset]
       @by_star_scope       ||= options[:scope]
+      @by_star_index_scope ||= options[:index_scope]
     end
 
     def by_star_offset(options = {})
@@ -63,6 +64,23 @@ module ByStar
       options = args.extract_options!.symbolize_keys!
       time = args.first || Time.zone.now
       block.call(time, options)
+    end
+
+    def by_star_eval_index_scope(start_time, end_time, options)
+      value = options[:index_scope] || @by_star_index_scope
+      value = value.call(start_time, end_time, options) if value.is_a?(Proc)
+      case value
+        when nil, false then nil
+        when Time then value
+        when DateTime then value.to_time
+        when Date then value.in_time_zone
+        when ActiveSupport::Duration then start_time - value
+        when Numeric then start_time - value.seconds
+        when :beginning_of_day
+          offset = options[:offset] || 0
+          (start_time - offset).beginning_of_day + offset
+        else raise 'ByStar :index_scope option value is not a supported type.'
+      end
     end
   end
 end

--- a/lib/by_star/between.rb
+++ b/lib/by_star/between.rb
@@ -16,8 +16,8 @@ module ByStar
 
       start_field = by_star_start_field(options)
       end_field = by_star_end_field(options)
-      scope = by_star_scope(options)
 
+      scope = by_star_scope(options)
       scope = if !start_time && !end_time
                 scope # do nothing
               elsif !end_time
@@ -29,12 +29,27 @@ module ByStar
               elsif options[:strict]
                 by_star_span_strict_query(scope, start_field, end_field, start_time, end_time)
               else
-                by_star_span_overlap_query(scope, start_field, end_field, start_time, end_time, options)
+                by_star_span_loose_query(scope, start_field, end_field, start_time, end_time, options)
               end
 
       scope = by_star_order(scope, options[:order]) if options[:order]
-
       scope
+    end
+
+    def at_time(*args)
+      with_by_star_options(*args) do |time, options|
+        start_field = by_star_start_field(options)
+        end_field = by_star_end_field(options)
+
+        scope = by_star_scope(options)
+        scope = if start_field == end_field
+                  by_star_point_overlap_query(scope, start_field, time)
+                else
+                  by_star_span_overlap_query(scope, start_field, end_field, time, options)
+                end
+        scope = by_star_order(scope, options[:order]) if options[:order]
+        scope
+      end
     end
 
     def by_day(*args)

--- a/lib/by_star/orm/active_record/by_star.rb
+++ b/lib/by_star/orm/active_record/by_star.rb
@@ -19,8 +19,22 @@ module ByStar
         scope.where("#{start_field} >= ? AND #{start_field} <= ? AND #{end_field} >= ? AND #{end_field} <= ?", start_time, end_time, start_time, end_time)
       end
 
-      def by_star_span_overlap_query(scope, start_field, end_field, start_time, end_time, options)
-        scope.where("#{end_field} > ? AND #{start_field} < ?", start_time, end_time)
+      def by_star_span_loose_query(scope, start_field, end_field, start_time, end_time, options)
+        index_scope = by_star_eval_index_scope(start_time, end_time, options)
+        scope = scope.where("#{end_field} > ? AND #{start_field} < ?", start_time, end_time)
+        scope = scope.where("#{start_field} >= ?", index_scope) if index_scope
+        scope
+      end
+
+      def by_star_point_overlap_query(scope, field, time)
+        scope.where("#{field} = ?", time)
+      end
+
+      def by_star_span_overlap_query(scope, start_field, end_field, time, options)
+        index_scope = by_star_eval_index_scope(time, time, options)
+        scope = scope.where("#{end_field} > ? AND #{start_field} <= ?", time, time)
+        scope = scope.where("#{start_field} >= ?", index_scope) if index_scope
+        scope
       end
 
       def by_star_before_query(scope, field, time)

--- a/lib/by_star/orm/mongoid/by_star.rb
+++ b/lib/by_star/orm/mongoid/by_star.rb
@@ -35,8 +35,22 @@ module Mongoid
         scope.where(start_field => range).where(end_field => range)
       end
 
-      def by_star_span_overlap_query(scope, start_field, end_field, start_time, end_time, options)
-        scope.gt(end_field => start_time).lt(start_field => end_time)
+      def by_star_span_loose_query(scope, start_field, end_field, start_time, end_time, options)
+        index_scope = by_star_eval_index_scope(start_time, end_time, options)
+        scope = scope.gt(end_field => start_time).lt(start_field => end_time)
+        scope = scope.gte(start_field => index_scope) if index_scope
+        scope
+      end
+
+      def by_star_point_overlap_query(scope, field, time)
+        scope.where(field => time)
+      end
+
+      def by_star_span_overlap_query(scope, start_field, end_field, time, options)
+        index_scope = by_star_eval_index_scope(time, time, options)
+        scope = scope.gt(end_field => time).lte(start_field => time)
+        scope = scope.gte(start_field => index_scope) if index_scope
+        scope
       end
 
       def by_star_before_query(scope, field, time)

--- a/spec/fixtures/active_record/models.rb
+++ b/spec/fixtures/active_record/models.rb
@@ -2,7 +2,7 @@ class Post < ActiveRecord::Base
 end
 
 class Appointment < ActiveRecord::Base
-  by_star_field scope: ->{ where(day_of_month: 1) }
+  by_star_field scope: ->{ where(day_of_month: 1) }, index_scope: ->(start){ start - 5.days }
 end
 
 class Event < ActiveRecord::Base

--- a/spec/fixtures/mongoid/models.rb
+++ b/spec/fixtures/mongoid/models.rb
@@ -13,7 +13,7 @@ class Appointment
 
   field :day_of_month,        type: Integer
 
-  by_star_field scope: ->{ where(day_of_month: 1) }
+  by_star_field scope: ->{ where(day_of_month: 1) }, index_scope: ->(start){ start - 5.days }
 end
 
 class Event

--- a/spec/integration/active_record/active_record_spec.rb
+++ b/spec/integration/active_record/active_record_spec.rb
@@ -21,9 +21,11 @@ describe ActiveRecord do
   end
 
   it_behaves_like 'between_times'
+  it_behaves_like 'at_time'
   it_behaves_like 'offset parameter'
   it_behaves_like 'order parameter'
   it_behaves_like 'scope parameter'
+  it_behaves_like 'index_scope parameter'
   it_behaves_like 'by day'
   it_behaves_like 'by direction'
   it_behaves_like 'by fortnight'

--- a/spec/integration/mongoid/mongoid_spec.rb
+++ b/spec/integration/mongoid/mongoid_spec.rb
@@ -20,9 +20,11 @@ describe 'Mongoid' do
   end
 
   it_behaves_like 'between_times'
+  it_behaves_like 'at_time'
   it_behaves_like 'offset parameter'
   it_behaves_like 'order parameter'
   it_behaves_like 'scope parameter'
+  it_behaves_like 'index_scope parameter'
   it_behaves_like 'by day'
   it_behaves_like 'by direction'
   it_behaves_like 'by fortnight'

--- a/spec/integration/shared/at_time.rb
+++ b/spec/integration/shared/at_time.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+shared_examples_for 'at_time' do
+
+  describe '#at_time' do
+
+    context 'point object' do
+
+      context 'exactly equal' do
+        subject { Post.at_time(Time.zone.parse('2013-12-28 17:00:00')) }
+        it { expect(subject.count).to eql(1) }
+      end
+
+      context 'not exactly equal' do
+        subject { Post.at_time(Time.zone.parse('2013-12-28 17:00:01')) }
+        it { expect(subject.count).to eql(0) }
+      end
+    end
+
+    context 'timespan object' do
+
+      context 'before start time' do
+        subject { Event.at_time(Time.zone.parse('2013-12-23 16:59:59')) }
+        it { expect(subject.count).to eql(2) }
+      end
+
+      context 'at start time' do
+        subject { Event.at_time(Time.zone.parse('2013-12-23 17:00:00')) }
+        it { expect(subject.count).to eql(3) }
+      end
+
+      context 'after start time' do
+        subject { Event.at_time(Time.zone.parse('2013-12-23 17:00:01')) }
+        it { expect(subject.count).to eql(3) }
+      end
+
+      context 'before end time' do
+        subject { Event.at_time(Time.zone.parse('2013-11-06 16:59:59')) }
+        it { expect(subject.count).to eql(1) }
+      end
+
+      context 'at end time' do
+        subject { Event.at_time(Time.zone.parse('2013-11-06 17:00:00')) }
+        it { expect(subject.count).to eql(0) }
+      end
+
+      context 'after end time' do
+        subject { Event.at_time(Time.zone.parse('2013-11-06 17:00:01')) }
+        it { expect(subject.count).to eql(0) }
+      end
+    end
+  end
+end

--- a/spec/integration/shared/index_scope_parameter.rb
+++ b/spec/integration/shared/index_scope_parameter.rb
@@ -1,0 +1,111 @@
+require 'spec_helper'
+
+shared_examples_for 'index_scope parameter' do
+
+  describe ':scope' do
+
+    it 'should memoize the scope variable' do
+      expect(Event.instance_variable_get(:@by_star_index_scope)).to be_nil
+      expect(Post.instance_variable_get(:@by_star_index_scope)).to be_nil
+      expect(Appointment.instance_variable_get(:@by_star_index_scope)).to be_a Proc
+    end
+
+    context 'between_times with index_scope' do
+
+      context 'nil' do
+        subject { Event.between_times(Date.parse('2013-12-01'), Date.parse('2014-02-01'), index_scope: nil) }
+        it { expect(subject.count).to eql(16) }
+      end
+
+      context 'false' do
+        subject { Event.between_times(Date.parse('2013-12-01'), Date.parse('2014-02-01'), index_scope: false) }
+        it { expect(subject.count).to eql(16) }
+      end
+
+      context 'Time' do
+        subject { Event.between_times(Date.parse('2013-12-01'), Date.parse('2014-02-01'), index_scope: Time.zone.parse('2013-11-30 17:00:00')) }
+        it { expect(subject.count).to eql(14) }
+      end
+
+      context 'DateTime' do
+        subject { Event.between_times(Date.parse('2013-12-01'), Date.parse('2014-02-01'), index_scope: Time.zone.parse('2013-11-30 17:00:00').to_datetime) }
+        it { expect(subject.count).to eql(14) }
+      end
+
+      context 'Date' do
+        subject { Event.between_times(Date.parse('2013-12-01'), Date.parse('2014-02-01'), index_scope: Date.parse('2013-11-30')) }
+        it { expect(subject.count).to eql(14) }
+      end
+
+      context 'ActiveSupport::Duration' do
+        subject { Event.between_times(Date.parse('2013-12-01'), Date.parse('2014-02-01'), index_scope: 3.hours) }
+        it { expect(subject.count).to eql(13) }
+      end
+
+      context 'Numeric' do
+        subject { Event.between_times(Date.parse('2013-12-01'), Date.parse('2014-02-01'), index_scope: 3600) }
+        it { expect(subject.count).to eql(13) }
+      end
+
+      context ':beginning_of_day' do
+        subject { Event.between_times(Date.parse('2013-12-01'), Date.parse('2014-02-01'), index_scope: :beginning_of_day) }
+        it { expect(subject.count).to eql(13) }
+      end
+
+      context 'unsupported type' do
+        subject { Event.between_times(Date.parse('2013-12-01'), Date.parse('2014-02-01'), index_scope: Integer) }
+        it { expect{subject.count}.to raise_error(RuntimeError) }
+      end
+    end
+
+    context 'at_time with index_scope' do
+
+      context 'nil' do
+        subject { Event.at_time(Time.zone.parse('2013-12-01 14:00'), index_scope: nil) }
+        it { expect(subject.count).to eql(3) }
+      end
+
+      context 'false' do
+        subject { Event.at_time(Time.zone.parse('2013-12-01 14:00'), index_scope: false) }
+        it { expect(subject.count).to eql(3) }
+      end
+
+      context 'Time' do
+        subject { Event.at_time(Time.zone.parse('2013-12-01 14:00'), index_scope: Time.zone.parse('2013-10-30 17:00:00')) }
+        it { expect(subject.count).to eql(3) }
+      end
+
+      context 'DateTime' do
+        subject { Event.at_time(Time.zone.parse('2013-12-01 14:00'), index_scope: Time.zone.parse('2013-11-30 17:00:00').to_datetime) }
+        it { expect(subject.count).to eql(1) }
+      end
+
+      context 'Date' do
+        subject { Event.at_time(Time.zone.parse('2013-12-01 14:00'), index_scope: Date.parse('2013-11-30')) }
+        it { expect(subject.count).to eql(1) }
+      end
+
+      context 'ActiveSupport::Duration' do
+        subject { Event.at_time(Time.zone.parse('2013-12-01 14:00'), index_scope: 100.hours) }
+        it { expect(subject.count).to eql(1) }
+      end
+
+      context 'Numeric' do
+        subject { Event.at_time(Time.zone.parse('2013-12-01 14:00'), index_scope: 60 * 60 * 1000) }
+        it { expect(subject.count).to eql(3) }
+      end
+
+      context ':beginning_of_day' do
+        let!(:custom_event){ t = Time.zone.parse('2013-12-30 17:00'); Event.create!(start_time: t - 1.hour, end_time: t + 1.hour) }
+        subject { Event.at_time(Time.zone.parse('2013-12-30 16:00'), index_scope: :beginning_of_day) }
+        it { expect(subject.count).to eql(1) }
+        after { custom_event.delete }
+      end
+
+      context 'unsupported type' do
+        subject { Event.at_time(Time.zone.parse('2013-12-01 14:00'), index_scope: Integer) }
+        it { expect{subject.count}.to raise_error(RuntimeError) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Add `#at_time` method for point-in-time query.
- Add optional `:index_scope` option for timespan "non-strict" queries to improve database performance.
