### PR TITLE
update-installation-readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Post.between_times(Time.zone.now - 3.hours,  # all posts in last 3 hours
 Install this gem by adding this to your Gemfile:
 
 ```ruby
-gem 'by_star', git: "git://github.com/radar/by_star"
+gem 'by_star', git: 'https://github.com/radar/by_star'
 ```
 
 Then run `bundle install`


### PR DESCRIPTION
Due to recent updates in github security, how we add the gem to the gem file has changed slightly.

https://github.blog/2021-09-01-improving-git-protocol-security-github/

(The solution is the second to last paragraph in the document)

Began getting the error:
```
: remote error:
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.

Git error: command `git fetch --force --quiet --tags 'git://github.com/radar/by_star' "refs/heads/*:refs/heads/*" ` in directory
```